### PR TITLE
Fix Rust CLI panic and add --test-loadbalancer support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -223,7 +223,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -283,6 +283,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,12 +311,15 @@ dependencies = [
  "fake",
  "metrics",
  "metrics-exporter-prometheus",
+ "native-tls",
  "ratatui",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
+ "tokio-native-tls",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -335,7 +348,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -465,6 +478,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "fake"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +517,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -880,7 +924,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
@@ -933,6 +977,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1093,6 +1143,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1208,50 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1194,6 +1305,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1295,7 +1412,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.11.0",
  "cassowary",
  "crossterm",
  "indoc",
@@ -1322,7 +1439,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1431,6 +1548,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1626,29 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1700,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1712,6 +1874,19 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1782,6 +1957,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2008,6 +2193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2345,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2188,12 +2379,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2202,7 +2399,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2242,6 +2439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,7 +2484,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2452,7 +2658,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,6 +51,10 @@ url = "2.0"
 # Base64 encoding for auth
 base64 = "0.21"
 
+# TLS for raw socket load balancer test
+native-tls = "0.2"
+tokio-native-tls = "0.3"
+
 
 # TOML parsing for config files
 toml = "0.8"
@@ -67,6 +71,9 @@ metrics-exporter-prometheus = { version = "0.12", optional = true }
 default = ["dashboard"]
 dashboard = ["crossterm", "ratatui"]
 prometheus = ["metrics-exporter-prometheus"]
+
+[dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/rust/config.toml
+++ b/rust/config.toml
@@ -1,0 +1,10 @@
+table_name = "performance_test"
+connection_string = "https://admin:hugohugohugohugoxxxxxxxxxxxxxxxxxxxxxxxxxx@xdemo.eks1.us-east-1.aws.cratedb-dev.net:4200"
+
+duration = 10
+batch_size = 500
+batch_interval = 50
+threads = 8
+objects = 0
+dashboard = true
+log_level = "info"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -153,6 +153,17 @@ impl CrateClient {
 
 
 
+    pub async fn execute_query(&self, sql: &str) -> Result<Vec<Vec<Value>>> {
+        let request = SqlRequest {
+            stmt: sql.to_string(),
+            args: None,
+            bulk_args: None,
+        };
+
+        let resp = self.make_request(&request).await?;
+        Ok(resp.rows)
+    }
+
     pub async fn test_connection(&self) -> Result<()> {
         self.execute("SELECT 1", &[]).await?;
         Ok(())

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
+use base64::Engine;
 use clap::Parser;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::{info, warn, error};
 
@@ -27,7 +29,7 @@ use config::Config;
 )]
 struct Cli {
     /// Name of the CrateDB table to insert records into
-    #[arg(long, required_unless_present = "test_loadbalancer")]
+    #[arg(long)]
     table_name: Option<String>,
 
     /// CrateDB connection string (can be read from .env file)
@@ -35,7 +37,7 @@ struct Cli {
     connection_string: Option<String>,
 
     /// Duration to run the generator (in minutes)
-    #[arg(long, required_unless_present = "test_loadbalancer")]
+    #[arg(long)]
     duration: Option<u64>,
 
     /// Number of records to insert in each batch
@@ -65,6 +67,10 @@ struct Cli {
     /// Configuration file path
     #[arg(long)]
     config: Option<PathBuf>,
+
+    /// Run only the 5-tuple load balancer test (no table creation or data insertion)
+    #[arg(long)]
+    test_loadbalancer: bool,
 }
 
 fn sanitize_connection_string(connection_string: &str) -> String {
@@ -268,6 +274,280 @@ async fn run_data_generation(
     Ok(())
 }
 
+struct FreshRequestResult {
+    node_name: String,
+    source_port: u16,
+    connect_time_ms: f64,
+    request_time_ms: f64,
+    total_time_ms: f64,
+}
+
+async fn make_fresh_request(
+    host: &str,
+    port: u16,
+    use_tls: bool,
+    auth_header: Option<&str>,
+) -> Result<FreshRequestResult> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use std::time::Instant;
+
+    let start_connect = Instant::now();
+
+    let addr = format!("{}:{}", host, port);
+    let stream = tokio::net::TcpStream::connect(&addr).await
+        .with_context(|| format!("Failed to connect to {}", addr))?;
+
+    let source_port = stream.local_addr()?.port();
+    let connect_time = start_connect.elapsed();
+
+    // Build HTTP request
+    let mut http_request = format!(
+        "GET / HTTP/1.1\r\nHost: {}:{}\r\nConnection: close\r\nUser-Agent: CrateDB-5Tuple-Tester/1.0\r\n",
+        host, port
+    );
+    if let Some(auth) = auth_header {
+        http_request.push_str(&format!("Authorization: {}\r\n", auth));
+    }
+    http_request.push_str("\r\n");
+
+    let start_request = Instant::now();
+
+    if use_tls {
+        let connector = tokio_native_tls::TlsConnector::from(
+            native_tls::TlsConnector::builder()
+                .danger_accept_invalid_certs(true)
+                .build()?,
+        );
+        let mut tls_stream = connector.connect(host, stream).await?;
+        tls_stream.write_all(http_request.as_bytes()).await?;
+        let mut response_data = Vec::new();
+        tls_stream.read_to_end(&mut response_data).await?;
+        let request_time = start_request.elapsed();
+        let node_name = parse_node_name(&response_data);
+        Ok(FreshRequestResult {
+            node_name,
+            source_port,
+            connect_time_ms: connect_time.as_secs_f64() * 1000.0,
+            request_time_ms: request_time.as_secs_f64() * 1000.0,
+            total_time_ms: start_connect.elapsed().as_secs_f64() * 1000.0,
+        })
+    } else {
+        let mut stream = stream;
+        stream.write_all(http_request.as_bytes()).await?;
+        let mut response_data = Vec::new();
+        stream.read_to_end(&mut response_data).await?;
+        let request_time = start_request.elapsed();
+        let node_name = parse_node_name(&response_data);
+        Ok(FreshRequestResult {
+            node_name,
+            source_port,
+            connect_time_ms: connect_time.as_secs_f64() * 1000.0,
+            request_time_ms: request_time.as_secs_f64() * 1000.0,
+            total_time_ms: start_connect.elapsed().as_secs_f64() * 1000.0,
+        })
+    }
+}
+
+fn parse_node_name(response_data: &[u8]) -> String {
+    let response_text = String::from_utf8_lossy(response_data);
+    // Split headers from body
+    if let Some(body_start) = response_text.find("\r\n\r\n") {
+        let body = &response_text[body_start + 4..];
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
+            if let Some(name) = json.get("name").and_then(|v| v.as_str()) {
+                return shorten_node_name(name);
+            }
+        }
+    }
+    "unknown".to_string()
+}
+
+fn shorten_node_name(name: &str) -> String {
+    // Extract pattern like "prefix" + "number" from node names
+    let re_like: Option<(String, String)> = {
+        let mut alpha = String::new();
+        let mut digit = String::new();
+        let mut found_digit = false;
+        for ch in name.chars() {
+            if !found_digit && ch.is_alphabetic() {
+                alpha.push(ch);
+            } else if ch.is_ascii_digit() {
+                found_digit = true;
+                digit.push(ch);
+            }
+        }
+        if !alpha.is_empty() && !digit.is_empty() {
+            Some((alpha, digit))
+        } else {
+            None
+        }
+    };
+
+    match re_like {
+        Some((prefix, num)) => format!("{}-{}", prefix, num),
+        None => name.chars().take(10).collect(),
+    }
+}
+
+async fn test_5tuple_distribution(connection_string: &str) -> Result<()> {
+    let parsed = url::Url::parse(connection_string)
+        .context("Invalid connection string")?;
+
+    let host = parsed.host_str().context("Missing hostname")?.to_string();
+    let port = parsed.port().unwrap_or(4200);
+    let use_tls = parsed.scheme() == "https";
+
+    let auth_header = if let Some(password) = parsed.password() {
+        let username = parsed.username();
+        let credentials = format!("{}:{}", username, password);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
+        Some(format!("Basic {}", encoded))
+    } else {
+        None
+    };
+
+    println!("🔍 5-TUPLE LOAD BALANCER TEST");
+    println!("{}", "=".repeat(60));
+    println!("Target: {}:{} ({})", host, port, if use_tls { "HTTPS" } else { "HTTP" });
+
+    // Query sys.nodes to determine cluster size
+    let expected_nodes = {
+        let client = CrateClient::new(connection_string).await?;
+        match client.execute_query("SELECT count(*) as node_count FROM sys.nodes").await {
+            Ok(rows) => {
+                if let Some(first) = rows.first() {
+                    if let Some(first_val) = first.first() {
+                        first_val.as_u64().unwrap_or(1) as usize
+                    } else { 1 }
+                } else { 1 }
+            }
+            Err(_) => {
+                println!("⚠️  Could not determine cluster size, assuming 1 node");
+                1
+            }
+        }
+    };
+    println!("✅ Cluster has {} node(s)", expected_nodes);
+
+    let num_requests = std::cmp::max(30, expected_nodes * 30);
+    println!("📊 Test plan: {} requests ({} per expected node)", num_requests, num_requests / expected_nodes);
+    println!();
+
+    println!("📊 Request Details:");
+    println!("Req# |    Node    | SrcPort | ConnTime | ReqTime | TotalTime");
+    println!("{}", "-".repeat(65));
+
+    let mut node_counts: HashMap<String, usize> = HashMap::new();
+    let mut source_ports: Vec<u16> = Vec::new();
+    let mut failed_requests = 0usize;
+    let mut successful_requests = 0usize;
+    let mut total_connect_ms = 0.0f64;
+    let mut total_request_ms = 0.0f64;
+    let mut total_time_ms = 0.0f64;
+
+    for i in 0..num_requests {
+        match make_fresh_request(&host, port, use_tls, auth_header.as_deref()).await {
+            Ok(result) => {
+                if result.node_name == "unknown" || result.node_name.starts_with("error") {
+                    failed_requests += 1;
+                    println!("{:4} | {:10} | {:>7} | {:>8} | {:>7} | ERROR", i + 1, "ERROR", "N/A", "N/A", "N/A");
+                } else {
+                    *node_counts.entry(result.node_name.clone()).or_insert(0) += 1;
+                    source_ports.push(result.source_port);
+                    successful_requests += 1;
+                    total_connect_ms += result.connect_time_ms;
+                    total_request_ms += result.request_time_ms;
+                    total_time_ms += result.total_time_ms;
+
+                    println!(
+                        "{:4} | {:10} | {:7} | {:6.1}ms | {:5.1}ms | {:7.1}ms",
+                        i + 1, result.node_name, result.source_port,
+                        result.connect_time_ms, result.request_time_ms, result.total_time_ms
+                    );
+                }
+            }
+            Err(e) => {
+                failed_requests += 1;
+                println!("{:4} | {:10} | {:>7} | {:>8} | {:>7} | {}", i + 1, "ERROR", "N/A", "N/A", "N/A", e);
+            }
+        }
+
+        // Small delay to ensure different source ports
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    println!("{}", "-".repeat(65));
+
+    let unique_ports = source_ports.iter().collect::<std::collections::HashSet<_>>().len();
+    let unique_nodes = node_counts.len();
+
+    // Summary
+    println!("\n📊 SUMMARY:");
+    println!("   Total requests: {}", num_requests);
+    println!("   Successful: {}", successful_requests);
+    println!("   Failed: {}", failed_requests);
+    println!("   Unique source ports: {}", unique_ports);
+    println!("   Unique nodes hit: {}", unique_nodes);
+
+    if successful_requests > 0 {
+        println!("   Avg connect time: {:.1}ms", total_connect_ms / successful_requests as f64);
+        println!("   Avg request time: {:.1}ms", total_request_ms / successful_requests as f64);
+        println!("   Avg total time: {:.1}ms", total_time_ms / successful_requests as f64);
+    }
+
+    // Distribution
+    println!("\n📈 NODE DISTRIBUTION:");
+    let mut sorted_nodes: Vec<_> = node_counts.iter().collect();
+    sorted_nodes.sort_by_key(|(name, _)| name.clone());
+    for (name, count) in &sorted_nodes {
+        let percentage = (**count as f64 / successful_requests as f64) * 100.0;
+        let bar = "█".repeat((percentage / 2.0) as usize);
+        println!("   {:15} | {:3} hits | {:5.1}% | {}", name, count, percentage, bar);
+    }
+
+    // 5-tuple analysis
+    println!("\n🔍 5-TUPLE LOAD BALANCING ANALYSIS:");
+    if unique_ports < 2 {
+        println!("   ❌ INCONCLUSIVE: Need more unique source ports to test");
+    } else {
+        println!("   ✅ Good test conditions: {} different source ports", unique_ports);
+
+        if unique_nodes == 1 {
+            println!("   🚨 VERDICT: Load balancer NOT using 5-tuple distribution");
+            println!("   📝 Evidence: {} different source ports, but all hit same node", unique_ports);
+        } else if unique_nodes > 1 {
+            println!("   ✅ VERDICT: Load balancer IS distributing across nodes");
+            println!("   📝 Evidence: {} source ports hit {} different nodes", unique_ports, unique_nodes);
+        }
+    }
+
+    // Final verdict
+    println!("\n{}", "=".repeat(60));
+    println!("🎯 FINAL VERDICT");
+    println!("{}", "=".repeat(60));
+    println!("📊 CLUSTER ANALYSIS:");
+    println!("   Expected nodes: {}", expected_nodes);
+    println!("   Nodes hit during test: {}", unique_nodes);
+
+    if unique_nodes == expected_nodes {
+        println!("   ✅ Perfect distribution - hit all {} nodes", expected_nodes);
+    } else if unique_nodes < expected_nodes {
+        println!("   ⚠️  Partial distribution - hit {}/{} nodes", unique_nodes, expected_nodes);
+    } else {
+        println!("   🤔 Unexpected - hit more nodes ({}) than expected ({})", unique_nodes, expected_nodes);
+    }
+
+    if unique_nodes == 1 && unique_ports > 5 {
+        println!("\n🚨 CONFIRMED: Load balancer NOT using 5-tuple distribution");
+        println!("💡 Contact CrateDB Cloud support about load balancer config");
+    } else if unique_nodes > 1 {
+        println!("\n✅ Load balancer IS distributing traffic across nodes");
+        println!("🔧 Performance tests will distribute across nodes");
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Load environment variables from .env file FIRST
@@ -306,9 +586,37 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Load configuration
+    // Handle load balancer test mode
+    if cli.test_loadbalancer {
+        // Need a connection string for the test
+        let connection_string = cli.connection_string
+            .or_else(|| std::env::var("CRATE_CONNECTION_STRING").ok())
+            .context("Connection string required: use --connection-string or CRATE_CONNECTION_STRING env var")?;
+
+        info!("🚀 CrateDB 5-Tuple Load Balancer Test");
+        info!("{}", "=".repeat(60));
+        info!("This test creates fresh TCP connections to properly test");
+        info!("whether load balancers use 5-tuple hashing for distribution.");
+        info!("🔗 Connection: {}", sanitize_connection_string(&connection_string));
+
+        match test_5tuple_distribution(&connection_string).await {
+            Ok(_) => {
+                info!("✅ Load balancer test completed successfully");
+                return Ok(());
+            }
+            Err(e) => {
+                error!("❌ Load balancer test failed: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Load configuration: explicit --config, or auto-detect config.toml, or defaults
     let mut config = if let Some(config_path) = cli.config {
         Config::from_file(&config_path)?
+    } else if Path::new("config.toml").exists() {
+        info!("✅ Auto-detected config.toml in current directory");
+        Config::from_file("config.toml")?
     } else {
         Config::default()
     };


### PR DESCRIPTION
## Summary
- Fix panic on clap 4.5+ caused by `required_unless_present` referencing a non-existent `test_loadbalancer` argument
- Add `--test-loadbalancer` flag with full 5-tuple load balancer distribution test (raw TCP connections, TLS support, node distribution analysis) — matching the Python implementation
- Fix config loading: remove hard CLI requirement for `--table-name`/`--duration` so they can come from `config.toml` or `.env`; auto-detect `config.toml` in current directory
- Add `execute_query` to `CrateClient` for queries that return rows
- Add missing `tempfile` dev-dependency

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 19 tests pass
- [x] `cargo run -- --help` shows `--test-loadbalancer` flag, no panic
- [x] `cargo run -- --test-loadbalancer` runs 5-tuple test against live cluster
- [x] `cargo run` with no args picks up `config.toml` and `.env` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)