### PR TITLE
Maximize Rust insert throughput and verify records

### DIFF
--- a/rust/config.toml
+++ b/rust/config.toml
@@ -1,10 +1,10 @@
 table_name = "performance_test"
-connection_string = "https://admin:hugohugohugohugoxxxxxxxxxxxxxxxxxxxxxxxxxx@xdemo.eks1.us-east-1.aws.cratedb-dev.net:4200"
+# connection_string from .env or CRATE_CONNECTION_STRING env var
 
 duration = 10
-batch_size = 500
-batch_interval = 50
-threads = 8
+batch_size = 1000
+batch_interval = 0
+threads = 32
 objects = 0
-dashboard = true
+dashboard = false
 log_level = "info"

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -26,19 +26,21 @@ struct SqlRequest {
 #[derive(Debug, Deserialize)]
 pub struct SqlResponse {
     #[serde(default)]
-    rows: Vec<Vec<Value>>,
+    pub rows: Vec<Vec<Value>>,
     #[serde(default)]
-    rowcount: i64,
+    pub rowcount: i64,
     #[serde(default)]
-    duration: f64,
+    pub duration: f64,
     #[serde(default)]
     cols: Vec<String>,
 }
 
-
-
 impl CrateClient {
     pub async fn new(connection_string: &str) -> Result<Self> {
+        Self::with_pool_size(connection_string, 50).await
+    }
+
+    pub async fn with_pool_size(connection_string: &str, pool_size: usize) -> Result<Self> {
         let url = Url::parse(connection_string)
             .with_context(|| format!("Invalid connection string: {}", connection_string))?;
 
@@ -61,9 +63,9 @@ impl CrateClient {
 
         // Build HTTP client with optimized settings
         let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(60))
             .tcp_keepalive(std::time::Duration::from_secs(60))
-            .pool_max_idle_per_host(50)
+            .pool_max_idle_per_host(pool_size)
             .pool_idle_timeout(std::time::Duration::from_secs(90))
             .user_agent("crate-write-rs/0.1.0")
             .build()
@@ -127,7 +129,8 @@ impl CrateClient {
         self.make_request(&request).await.map(|_| ())
     }
 
-    pub async fn execute_bulk(&self, sql: &str, bulk_args: &[Vec<Value>]) -> Result<()> {
+    /// Accept owned bulk_args to avoid copying the entire payload
+    pub async fn execute_bulk(&self, sql: &str, bulk_args: Vec<Vec<Value>>) -> Result<()> {
         if bulk_args.is_empty() {
             return Ok(());
         }
@@ -135,7 +138,7 @@ impl CrateClient {
         let request = SqlRequest {
             stmt: sql.to_string(),
             args: None,
-            bulk_args: Some(bulk_args.to_vec()),
+            bulk_args: Some(bulk_args), // moved, not copied
         };
 
         match self.make_request(&request).await {
@@ -145,13 +148,11 @@ impl CrateClient {
                 Ok(())
             }
             Err(e) => {
-                error!("Bulk insert failed for {} records: {}", bulk_args.len(), e);
+                error!("Bulk insert failed: {}", e);
                 Err(e)
             }
         }
     }
-
-
 
     pub async fn execute_query(&self, sql: &str) -> Result<Vec<Vec<Value>>> {
         let request = SqlRequest {

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -89,8 +89,8 @@ impl Config {
             anyhow::bail!("Number of threads cannot exceed 1000");
         }
 
-        if self.batch_size > 10000 {
-            anyhow::bail!("Batch size cannot exceed 10000");
+        if self.batch_size > 100000 {
+            anyhow::bail!("Batch size cannot exceed 100000");
         }
 
         if self.batch_interval > 60000 {

--- a/rust/src/generator.rs
+++ b/rust/src/generator.rs
@@ -56,7 +56,7 @@ impl RecordGenerator {
         }
     }
 
-    pub async fn generate_record(&self) -> Record {
+    pub fn generate_record(&self) -> Record {
         let id = Uuid::new_v4().to_string();
         let timestamp = Utc::now();
 
@@ -106,33 +106,34 @@ impl RecordGenerator {
         }
     }
 
-    pub async fn generate_batch(&self, batch_size: usize) -> Vec<Record> {
+    pub fn generate_batch(&self, batch_size: usize) -> Vec<Record> {
         let mut batch = Vec::with_capacity(batch_size);
         for _ in 0..batch_size {
-            batch.push(self.generate_record().await);
+            batch.push(self.generate_record());
         }
         batch
     }
 }
 
 impl Record {
-    pub fn to_params(&self) -> Vec<Value> {
+    /// Consume the record and convert to params, avoiding clones
+    pub fn into_params(self) -> Vec<Value> {
         let mut params = vec![
-            json!(self.id),
-            json!(self.timestamp.to_rfc3339()),
-            json!(self.region),
-            json!(self.product_category),
-            json!(self.event_type),
+            Value::String(self.id),
+            Value::String(self.timestamp.to_rfc3339()),
+            Value::String(self.region),
+            Value::String(self.product_category),
+            Value::String(self.event_type),
             json!(self.user_id),
-            json!(self.user_segment),
+            Value::String(self.user_segment),
             json!(self.amount),
             json!(self.quantity),
-            self.metadata.clone(),
+            self.metadata, // moved, not cloned
         ];
 
         // Add object columns
-        for obj_val in &self.objects {
-            params.push(json!(obj_val));
+        for obj_val in self.objects {
+            params.push(Value::String(obj_val));
         }
 
         params
@@ -143,10 +144,10 @@ impl Record {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_record_generation() {
+    #[test]
+    fn test_record_generation() {
         let generator = RecordGenerator::new(0);
-        let record = generator.generate_record().await;
+        let record = generator.generate_record();
 
         assert!(!record.id.is_empty());
         assert!(record.user_id >= 1 && record.user_id <= 10000);
@@ -155,10 +156,10 @@ mod tests {
         assert!(record.objects.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_record_generation_with_objects() {
+    #[test]
+    fn test_record_generation_with_objects() {
         let generator = RecordGenerator::new(3);
-        let record = generator.generate_record().await;
+        let record = generator.generate_record();
 
         assert_eq!(record.objects.len(), 3);
         for (i, obj_val) in record.objects.iter().enumerate() {
@@ -166,10 +167,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_batch_generation() {
+    #[test]
+    fn test_batch_generation() {
         let generator = RecordGenerator::new(2);
-        let batch = generator.generate_batch(10).await;
+        let batch = generator.generate_batch(10);
 
         assert_eq!(batch.len(), 10);
 
@@ -196,7 +197,7 @@ mod tests {
             objects: vec!["obj0_val_1".to_string(), "obj1_val_2".to_string()],
         };
 
-        let params = record.to_params();
+        let params = record.into_params();
         assert_eq!(params.len(), 12); // 10 base + 2 objects
 
         assert_eq!(params[0], json!("test-id"));

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -178,22 +178,22 @@ async fn run_data_generation(
                         break;
                     }
                     _ = async {
-                        // Generate batch
-                        let batch = generator.generate_batch(batch_size).await;
+                        // Generate batch (sync — no async overhead for CPU work)
+                        let batch = generator.generate_batch(batch_size);
 
-                        // Convert to parameters
+                        // Convert to parameters, consuming records (no clones)
                         let params: Vec<Vec<serde_json::Value>> = batch.into_iter()
-                            .map(|record| record.to_params())
+                            .map(|record| record.into_params())
                             .collect();
 
-                        // Insert batch
-                        match client.execute_bulk(&insert_sql, &params).await {
+                        // Insert batch (owned Vec — no .to_vec() copy)
+                        match client.execute_bulk(&insert_sql, params).await {
                             Ok(_) => {
-                                monitor.add_records(batch_size).await;
+                                monitor.add_records(batch_size);
                             }
                             Err(e) => {
                                 error!("Worker {} error: {}", worker_id, e);
-                                monitor.add_error().await;
+                                monitor.add_error();
                             }
                         }
 
@@ -258,18 +258,55 @@ async fn run_data_generation(
     let _ = reporting_task.await;
 
     // Final statistics
-    let final_stats = monitor.get_final_stats().await;
+    let final_stats = monitor.get_final_stats_async().await;
     info!("{}", "=".repeat(60));
     info!("FINAL PERFORMANCE SUMMARY");
     info!("{}", "=".repeat(60));
     info!("✅ Worker threads: {}", config.threads);
-    info!("✅ Total records inserted: {}", final_stats.total_records);
+    info!("✅ Total records sent: {}", final_stats.total_records);
     info!("✅ Total batches: {}", final_stats.total_batches);
     info!("✅ Total runtime: {:.1} seconds", final_stats.runtime_seconds);
     info!("✅ Average insertion rate: {:.1} records/second", final_stats.average_rate);
     info!("✅ Records per thread: {:.0} avg", final_stats.total_records as f64 / config.threads as f64);
     info!("✅ Total errors: {}", final_stats.total_errors);
     info!("{}", "=".repeat(60));
+
+    // Verify records in CrateDB match what we sent
+    info!("Verifying record count in CrateDB...");
+
+    // Refresh the table to ensure all records are visible
+    let refresh_sql = format!("REFRESH TABLE {}", table_name);
+    if let Err(e) = client.execute(&refresh_sql, &[]).await {
+        warn!("Failed to refresh table: {}", e);
+    }
+
+    let count_sql = format!("SELECT COUNT(*) FROM {}", table_name);
+    match client.execute_query(&count_sql).await {
+        Ok(rows) => {
+            if let Some(count) = rows.first().and_then(|r| r.first()).and_then(|v| v.as_u64()) {
+                let sent = final_stats.total_records;
+                info!("{}", "=".repeat(60));
+                info!("RECORD VERIFICATION");
+                info!("{}", "=".repeat(60));
+                info!("Records sent by client: {}", sent);
+                info!("Records in CrateDB:     {}", count);
+                if count == sent {
+                    info!("✅ MATCH - all records accounted for");
+                } else if count > sent {
+                    info!("ℹ️  CrateDB has {} more records (table had pre-existing data)", count - sent);
+                } else {
+                    let missing = sent - count;
+                    let loss_pct = (missing as f64 / sent as f64) * 100.0;
+                    warn!("⚠️  MISMATCH - {} records missing ({:.2}% loss)", missing, loss_pct);
+                    warn!("   Possible causes: bulk insert partial failures, replication lag");
+                }
+                info!("{}", "=".repeat(60));
+            }
+        }
+        Err(e) => {
+            warn!("Failed to verify record count: {}", e);
+        }
+    }
 
     Ok(())
 }
@@ -642,8 +679,10 @@ async fn main() -> Result<()> {
     info!("🚀 CrateDB Record Generator (Rust)");
     info!("Connection: {}", sanitize_connection_string(config.connection_string.as_ref().unwrap()));
 
-    // Create client
-    let client = CrateClient::new(config.connection_string.as_ref().unwrap()).await?;
+    // Create client with connection pool sized to thread count
+    let pool_size = std::cmp::max(config.threads + 2, 10);
+    let client = CrateClient::with_pool_size(config.connection_string.as_ref().unwrap(), pool_size).await?;
+    info!("Connection pool size: {}", pool_size);
 
     // Create performance monitor
     let monitor = PerformanceMonitor::new();

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
@@ -11,159 +12,153 @@ pub struct PerformanceStats {
     pub current_rate: f64,
     pub average_rate: f64,
     pub runtime_seconds: f64,
-    pub last_batch_time: Option<Instant>,
 }
 
-#[derive(Debug)]
-struct MonitorState {
-    total_records: u64,
-    total_batches: u64,
-    total_errors: u64,
+/// Time-tracking state that needs a lock (read infrequently)
+struct TimingState {
     start_time: Instant,
     last_report_time: Instant,
     last_report_records: u64,
-    records_in_last_period: u64,
+}
+
+/// Lock-free counters for the hot path
+struct Counters {
+    total_records: AtomicU64,
+    total_batches: AtomicU64,
+    total_errors: AtomicU64,
 }
 
 #[derive(Clone)]
 pub struct PerformanceMonitor {
-    state: Arc<RwLock<MonitorState>>,
+    counters: Arc<Counters>,
+    timing: Arc<RwLock<TimingState>>,
 }
 
 impl PerformanceMonitor {
     pub fn new() -> Self {
         let now = Instant::now();
-        let state = MonitorState {
-            total_records: 0,
-            total_batches: 0,
-            total_errors: 0,
-            start_time: now,
-            last_report_time: now,
-            last_report_records: 0,
-            records_in_last_period: 0,
-        };
 
         Self {
-            state: Arc::new(RwLock::new(state)),
+            counters: Arc::new(Counters {
+                total_records: AtomicU64::new(0),
+                total_batches: AtomicU64::new(0),
+                total_errors: AtomicU64::new(0),
+            }),
+            timing: Arc::new(RwLock::new(TimingState {
+                start_time: now,
+                last_report_time: now,
+                last_report_records: 0,
+            })),
         }
     }
 
-    pub async fn add_records(&self, count: usize) {
-        let mut state = self.state.write().await;
-        state.total_records += count as u64;
-        state.total_batches += 1;
-        state.records_in_last_period += count as u64;
-
-        debug!("Added {} records, total: {}", count, state.total_records);
+    /// Lock-free: no contention between workers
+    pub fn add_records(&self, count: usize) {
+        self.counters.total_records.fetch_add(count as u64, Ordering::Relaxed);
+        self.counters.total_batches.fetch_add(1, Ordering::Relaxed);
+        debug!("Added {} records", count);
     }
 
-    pub async fn add_error(&self) {
-        let mut state = self.state.write().await;
-        state.total_errors += 1;
-        debug!("Error recorded, total errors: {}", state.total_errors);
+    /// Lock-free: no contention between workers
+    pub fn add_error(&self) {
+        self.counters.total_errors.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Called only by the reporting task every 10 seconds
     pub async fn get_current_stats(&self) -> PerformanceStats {
-        let mut state = self.state.write().await;
+        let total_records = self.counters.total_records.load(Ordering::Relaxed);
+        let total_batches = self.counters.total_batches.load(Ordering::Relaxed);
+        let total_errors = self.counters.total_errors.load(Ordering::Relaxed);
+
+        let mut timing = self.timing.write().await;
         let now = Instant::now();
-        let total_runtime = now.duration_since(state.start_time);
-        let time_since_last_report = now.duration_since(state.last_report_time);
+        let total_runtime = now.duration_since(timing.start_time);
+        let time_since_last_report = now.duration_since(timing.last_report_time);
 
-        // Calculate current rate (records per second in the last period)
+        let records_since_last = total_records.saturating_sub(timing.last_report_records);
         let current_rate = if time_since_last_report.as_secs_f64() > 0.0 {
-            state.records_in_last_period as f64 / time_since_last_report.as_secs_f64()
+            records_since_last as f64 / time_since_last_report.as_secs_f64()
         } else {
             0.0
         };
 
-        // Calculate average rate
         let average_rate = if total_runtime.as_secs_f64() > 0.0 {
-            state.total_records as f64 / total_runtime.as_secs_f64()
+            total_records as f64 / total_runtime.as_secs_f64()
         } else {
             0.0
         };
 
-        // Reset period counters
-        state.last_report_time = now;
-        state.records_in_last_period = 0;
+        timing.last_report_time = now;
+        timing.last_report_records = total_records;
 
         PerformanceStats {
-            total_records: state.total_records,
-            total_batches: state.total_batches,
-            total_errors: state.total_errors,
+            total_records,
+            total_batches,
+            total_errors,
             current_rate,
             average_rate,
             runtime_seconds: total_runtime.as_secs_f64(),
-            last_batch_time: Some(now),
         }
     }
 
-    pub async fn get_final_stats(&self) -> PerformanceStats {
-        let state = self.state.read().await;
+    pub async fn get_final_stats_async(&self) -> PerformanceStats {
+        let total_records = self.counters.total_records.load(Ordering::Relaxed);
+        let total_batches = self.counters.total_batches.load(Ordering::Relaxed);
+        let total_errors = self.counters.total_errors.load(Ordering::Relaxed);
+
+        let timing = self.timing.read().await;
         let now = Instant::now();
-        let total_runtime = now.duration_since(state.start_time);
+        let total_runtime = now.duration_since(timing.start_time);
 
         let average_rate = if total_runtime.as_secs_f64() > 0.0 {
-            state.total_records as f64 / total_runtime.as_secs_f64()
+            total_records as f64 / total_runtime.as_secs_f64()
         } else {
             0.0
         };
 
         PerformanceStats {
-            total_records: state.total_records,
-            total_batches: state.total_batches,
-            total_errors: state.total_errors,
-            current_rate: 0.0, // Not meaningful for final stats
+            total_records,
+            total_batches,
+            total_errors,
+            current_rate: 0.0,
             average_rate,
             runtime_seconds: total_runtime.as_secs_f64(),
-            last_batch_time: Some(now),
         }
     }
 
     pub async fn reset(&self) {
-        let mut state = self.state.write().await;
-        let now = Instant::now();
+        self.counters.total_records.store(0, Ordering::Relaxed);
+        self.counters.total_batches.store(0, Ordering::Relaxed);
+        self.counters.total_errors.store(0, Ordering::Relaxed);
 
-        state.total_records = 0;
-        state.total_batches = 0;
-        state.total_errors = 0;
-        state.start_time = now;
-        state.last_report_time = now;
-        state.last_report_records = 0;
-        state.records_in_last_period = 0;
+        let mut timing = self.timing.write().await;
+        let now = Instant::now();
+        timing.start_time = now;
+        timing.last_report_time = now;
+        timing.last_report_records = 0;
 
         info!("Performance monitor reset");
     }
 
-    pub async fn get_throughput_history(&self, _duration_seconds: u64) -> Vec<(Instant, f64)> {
-        // This is a simplified version - in a full implementation,
-        // you might want to keep a rolling window of historical data
-        let state = self.state.read().await;
-        let now = Instant::now();
-        let average_rate = if state.start_time.elapsed().as_secs_f64() > 0.0 {
-            state.total_records as f64 / state.start_time.elapsed().as_secs_f64()
-        } else {
-            0.0
-        };
-
-        vec![(now, average_rate)]
+    pub fn get_total_records(&self) -> u64 {
+        self.counters.total_records.load(Ordering::Relaxed)
     }
 
-    /// Get error rate as percentage
     pub async fn get_error_rate(&self) -> f64 {
-        let state = self.state.read().await;
-        if state.total_batches > 0 {
-            (state.total_errors as f64 / state.total_batches as f64) * 100.0
+        let total_batches = self.counters.total_batches.load(Ordering::Relaxed);
+        let total_errors = self.counters.total_errors.load(Ordering::Relaxed);
+        if total_batches > 0 {
+            (total_errors as f64 / total_batches as f64) * 100.0
         } else {
             0.0
         }
     }
 
-    /// Get records per batch
-    pub async fn get_average_batch_size(&self) -> f64 {
-        let state = self.state.read().await;
-        if state.total_batches > 0 {
-            state.total_records as f64 / state.total_batches as f64
+    pub fn get_average_batch_size(&self) -> f64 {
+        let total_records = self.counters.total_records.load(Ordering::Relaxed);
+        let total_batches = self.counters.total_batches.load(Ordering::Relaxed);
+        if total_batches > 0 {
+            total_records as f64 / total_batches as f64
         } else {
             0.0
         }
@@ -185,9 +180,8 @@ mod tests {
     async fn test_monitor_basic_operations() {
         let monitor = PerformanceMonitor::new();
 
-        // Add some records
-        monitor.add_records(100).await;
-        monitor.add_records(50).await;
+        monitor.add_records(100);
+        monitor.add_records(50);
 
         let stats = monitor.get_current_stats().await;
         assert_eq!(stats.total_records, 150);
@@ -199,9 +193,9 @@ mod tests {
     async fn test_monitor_error_tracking() {
         let monitor = PerformanceMonitor::new();
 
-        monitor.add_records(100).await;
-        monitor.add_error().await;
-        monitor.add_records(50).await;
+        monitor.add_records(100);
+        monitor.add_error();
+        monitor.add_records(50);
 
         let stats = monitor.get_current_stats().await;
         assert_eq!(stats.total_records, 150);
@@ -216,7 +210,7 @@ mod tests {
     async fn test_monitor_rate_calculation() {
         let monitor = PerformanceMonitor::new();
 
-        monitor.add_records(100).await;
+        monitor.add_records(100);
 
         // Wait a bit to ensure time passes
         sleep(Duration::from_millis(10)).await;
@@ -230,8 +224,8 @@ mod tests {
     async fn test_monitor_reset() {
         let monitor = PerformanceMonitor::new();
 
-        monitor.add_records(100).await;
-        monitor.add_error().await;
+        monitor.add_records(100);
+        monitor.add_error();
 
         let stats_before = monitor.get_current_stats().await;
         assert_eq!(stats_before.total_records, 100);
@@ -247,11 +241,11 @@ mod tests {
     async fn test_average_batch_size() {
         let monitor = PerformanceMonitor::new();
 
-        monitor.add_records(100).await;
-        monitor.add_records(200).await;
-        monitor.add_records(50).await;
+        monitor.add_records(100);
+        monitor.add_records(200);
+        monitor.add_records(50);
 
-        let avg_batch_size = monitor.get_average_batch_size().await;
-        assert_eq!(avg_batch_size, 350.0 / 3.0); // Total records / total batches
+        let avg_batch_size = monitor.get_average_batch_size();
+        assert_eq!(avg_batch_size, 350.0 / 3.0);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `RwLock` monitor with `AtomicU64` counters — workers no longer contend for a lock on every batch
- Remove `async` from generator functions — pure CPU work doesn't need task scheduling overhead
- Use `into_params()` (consuming) instead of `to_params()` (cloning) — metadata JSON object is moved, not copied
- Accept owned `Vec` in `execute_bulk()` — eliminates `.to_vec()` copy of entire batch payload before serialization
- Scale connection pool to match thread count instead of fixed 50
- Raise `batch_size` validation cap from 10K to 100K
- After run completes: `REFRESH TABLE` + `SELECT COUNT(*)` to verify records in CrateDB match records sent
- Remove credentials from `config.toml` (rely on `.env`), update defaults: batch_size=1000, batch_interval=0, threads=32

## Test plan
- [x] `cargo test` — all 19 tests pass
- [x] `cargo run` loads config.toml and starts inserting
- [x] CLI help shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)