### PR TITLE
Add queue-based concurrency throttling to HTTP inserter

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -20,7 +20,7 @@ mod monitor;
 use client::CrateClient;
 use config::Config;
 use generator::RecordGenerator;
-use monitor::{PerformanceMonitor, ThreadPoolMonitor};
+use monitor::{PerformanceMonitor, QueueThrottleConfig, ThreadPoolMonitor};
 
 #[derive(Parser)]
 #[command(
@@ -124,6 +124,22 @@ struct Cli {
     /// Disable gzip compression (faster on localhost/low-latency)
     #[arg(long)]
     no_compression: bool,
+
+    /// Enable queue-based throttling (adjusts worker sleep based on write queue depth)
+    #[arg(long)]
+    queue_throttle: bool,
+
+    /// Write thread pool queue capacity (default: 200, matches CrateDB default)
+    #[arg(long, default_value_t = 200)]
+    queue_capacity: u64,
+
+    /// Queue fill percentage at which throttling starts (default: 50)
+    #[arg(long, default_value_t = 50)]
+    queue_throttle_pct: u64,
+
+    /// Maximum throttle sleep in milliseconds (default: 30)
+    #[arg(long, default_value_t = 30)]
+    queue_throttle_max_ms: u64,
 }
 
 fn sanitize_connection_string(connection_string: &str) -> String {
@@ -274,6 +290,7 @@ async fn run_data_generation(
     config: Config,
     monitor: PerformanceMonitor,
     benchmark: bool,
+    throttle_config: QueueThrottleConfig,
 ) -> Result<()> {
     let shared_worker_state = SharedWorkerState::new(&config);
 
@@ -355,9 +372,13 @@ async fn run_data_generation(
         let generator = RecordGenerator::new(config.objects);
         let insert_sql = insert_sql.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
-        let worker_state = shared_worker_state.clone(); // Clone for each worker
+        let worker_state = shared_worker_state.clone();
+        let throttle_us = tp_monitor.throttle_us.clone();
 
         let task = tokio::spawn(async move {
+            // Per-worker jitter seed based on worker_id
+            let jitter_factor = 0.8 + (worker_id as f64 % 10.0) * 0.04; // 0.80 to 1.16
+
             loop {
                 // Get current batch_size and batch_interval from shared state
                 let batch_size = worker_state.current_batch_size.load(Ordering::Relaxed);
@@ -438,6 +459,13 @@ async fn run_data_generation(
                             }
                         }
 
+                        // Queue-based throttle (read shared atomic, apply per-worker jitter)
+                        let throttle = throttle_us.load(Ordering::Relaxed);
+                        if throttle > 0 {
+                            let jittered = (throttle as f64 * jitter_factor) as u64;
+                            tokio::time::sleep(Duration::from_micros(jittered)).await;
+                        }
+
                         // Wait before next batch
                         if !batch_interval.is_zero() {
                             tokio::time::sleep(batch_interval).await;
@@ -451,7 +479,7 @@ async fn run_data_generation(
     }
 
     // Spawn thread pool poller (1s interval, collects active/queue per node)
-    let tp_poller = tp_monitor.spawn_poller(shutdown_tx.subscribe());
+    let tp_poller = tp_monitor.spawn_poller(shutdown_tx.subscribe(), throttle_config.clone());
 
     // Spawn reporting task (collects rate samples; logs only in non-benchmark mode)
     let monitor_clone = monitor.clone();
@@ -591,6 +619,10 @@ async fn run_data_generation(
                 "min_batch_interval": config.min_batch_interval,
                 "max_batch_interval": config.max_batch_interval,
                 "batch_interval_factor": config.batch_interval_factor,
+                "queue_throttle": throttle_config.enabled,
+                "queue_capacity": throttle_config.capacity,
+                "queue_throttle_pct": (throttle_config.threshold_pct * 100.0) as u64,
+                "queue_throttle_max_ms": throttle_config.max_throttle_us / 1000,
             },
             "results": {
                 "total_records": final_stats.total_records,
@@ -1205,7 +1237,13 @@ async fn main() -> Result<()> {
     let monitor = PerformanceMonitor::new();
 
     // Run data generation
-    run_data_generation(client, config, monitor, cli.benchmark).await?;
+    let throttle_config = QueueThrottleConfig {
+        enabled: cli.queue_throttle,
+        capacity: cli.queue_capacity,
+        threshold_pct: cli.queue_throttle_pct as f64 / 100.0,
+        max_throttle_us: cli.queue_throttle_max_ms * 1000, // ms to us
+    };
+    run_data_generation(client, config, monitor, cli.benchmark, throttle_config).await?;
 
     Ok(())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -137,8 +137,8 @@ struct Cli {
     #[arg(long, default_value_t = 50)]
     queue_throttle_pct: u64,
 
-    /// Maximum throttle sleep in milliseconds (default: 30)
-    #[arg(long, default_value_t = 30)]
+    /// Maximum throttle sleep in milliseconds (default: 100)
+    #[arg(long, default_value_t = 100)]
     queue_throttle_max_ms: u64,
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -137,9 +137,6 @@ struct Cli {
     #[arg(long, default_value_t = 50)]
     queue_throttle_pct: u64,
 
-    /// Maximum throttle sleep in milliseconds (default: 100)
-    #[arg(long, default_value_t = 100)]
-    queue_throttle_max_ms: u64,
 }
 
 fn sanitize_connection_string(connection_string: &str) -> String {
@@ -310,7 +307,7 @@ async fn run_data_generation(
     let cluster_info = query_cluster_info(&client).await;
 
     // Create thread pool monitor and capture baseline counters
-    let tp_monitor = ThreadPoolMonitor::new(client.clone());
+    let tp_monitor = ThreadPoolMonitor::new(client.clone(), config.threads);
     tp_monitor.capture_baseline().await;
 
     // Get pre-existing record count and rejected writes baseline
@@ -373,12 +370,10 @@ async fn run_data_generation(
         let insert_sql = insert_sql.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
         let worker_state = shared_worker_state.clone();
-        let throttle_us = tp_monitor.throttle_us.clone();
+        let concurrency_sem = tp_monitor.concurrency_sem.clone();
+        let throttle_enabled = throttle_config.enabled;
 
         let task = tokio::spawn(async move {
-            // Per-worker jitter seed based on worker_id
-            let jitter_factor = 0.8 + (worker_id as f64 % 10.0) * 0.04; // 0.80 to 1.16
-
             loop {
                 // Get current batch_size and batch_interval from shared state
                 let batch_size = worker_state.current_batch_size.load(Ordering::Relaxed);
@@ -401,6 +396,13 @@ async fn run_data_generation(
                                 .collect::<Vec<Vec<serde_json::Value>>>()
                         }).await.expect("batch generation panicked");
 
+                        // Acquire concurrency permit (blocks if throttle has reduced permits)
+                        let _permit = if throttle_enabled {
+                            Some(concurrency_sem.acquire().await.expect("semaphore closed"))
+                        } else {
+                            None
+                        };
+
                         // Insert batch
                         let (success, latency_ms) = match client.execute_bulk(&insert_sql, params).await {
                             Ok((bytes_sent, latency)) => {
@@ -411,9 +413,11 @@ async fn run_data_generation(
                             Err(e) => {
                                 error!("Worker {} error: {}", worker_id, e);
                                 monitor.add_error();
-                                (false, -1.0) // Indicate error with negative latency or handle differently
+                                (false, -1.0)
                             }
                         };
+
+                        drop(_permit); // release permit after response
 
                         // Adaptive batching logic
                         if worker_state.adaptive_batching_enabled {
@@ -457,13 +461,6 @@ async fn run_data_generation(
                                 worker_state.current_batch_interval.store(new_interval, Ordering::Relaxed);
                                 debug!("Worker {} (error) increased batch_interval to {}ms", worker_id, new_interval);
                             }
-                        }
-
-                        // Queue-based throttle (read shared atomic, apply per-worker jitter)
-                        let throttle = throttle_us.load(Ordering::Relaxed);
-                        if throttle > 0 {
-                            let jittered = (throttle as f64 * jitter_factor) as u64;
-                            tokio::time::sleep(Duration::from_micros(jittered)).await;
                         }
 
                         // Wait before next batch
@@ -622,7 +619,6 @@ async fn run_data_generation(
                 "queue_throttle": throttle_config.enabled,
                 "queue_capacity": throttle_config.capacity,
                 "queue_throttle_pct": (throttle_config.threshold_pct * 100.0) as u64,
-                "queue_throttle_max_ms": throttle_config.max_throttle_us / 1000,
             },
             "results": {
                 "total_records": final_stats.total_records,
@@ -639,6 +635,7 @@ async fn run_data_generation(
                 "rejected_pct": (rejected_writes as f64 / final_stats.total_records.max(1) as f64 * 100.0 * 100.0).round() / 100.0,
                 "average_batch_size": monitor.get_average_batch_size(),
                 "error_rate_pct": (monitor.get_error_rate().await * 10.0).round() / 10.0,
+                "final_concurrency": tp_monitor.current_concurrency.load(Ordering::Relaxed),
             }
         });
         println!("{}", serde_json::to_string(&result).unwrap());
@@ -1241,7 +1238,6 @@ async fn main() -> Result<()> {
         enabled: cli.queue_throttle,
         capacity: cli.queue_capacity,
         threshold_pct: cli.queue_throttle_pct as f64 / 100.0,
-        max_throttle_us: cli.queue_throttle_max_ms * 1000, // ms to us
     };
     run_data_generation(client, config, monitor, cli.benchmark, throttle_config).await?;
 

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -378,15 +378,14 @@ impl ThreadPoolMonitor {
                                 let queue_pct = avg_queue / throttle_config.capacity as f64;
 
                                 if queue_pct > throttle_config.threshold_pct {
-                                    // Pressure: ramp up fast
+                                    // Pressure: jump directly to proportional target
                                     let overshoot = (queue_pct - throttle_config.threshold_pct)
                                         / (1.0 - throttle_config.threshold_pct);
                                     let target = overshoot * throttle_config.max_throttle_us as f64;
-                                    // Fast up: jump to at least 70% old + 30% new, or new if higher
-                                    current_throttle = (0.7 * current_throttle + 0.3 * target)
-                                        .max(current_throttle.min(target));
+                                    // Always take the higher of current or target (never reduce under pressure)
+                                    current_throttle = current_throttle.max(target);
                                 } else {
-                                    // Headroom: slow decay
+                                    // Headroom: slow decay (10% per second)
                                     current_throttle *= 0.9;
                                 }
 

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -310,7 +310,6 @@ pub struct QueueThrottleConfig {
     pub enabled: bool,
     pub capacity: u64,
     pub threshold_pct: f64,
-    pub max_throttle_us: u64,
 }
 
 /// Monitors CrateDB write thread pool by polling sys.nodes during the benchmark.
@@ -318,17 +317,20 @@ pub struct ThreadPoolMonitor {
     client: CrateClient,
     samples: Arc<RwLock<std::collections::BTreeMap<String, Vec<NodeSample>>>>,
     baseline: Arc<RwLock<Vec<NodePoolCounters>>>,
-    /// Current throttle sleep in microseconds, read by workers.
-    pub throttle_us: Arc<AtomicU64>,
+    /// Semaphore controlling max concurrent in-flight requests.
+    pub concurrency_sem: Arc<tokio::sync::Semaphore>,
+    /// Current target concurrency (for reporting).
+    pub current_concurrency: Arc<AtomicU64>,
 }
 
 impl ThreadPoolMonitor {
-    pub fn new(client: CrateClient) -> Self {
+    pub fn new(client: CrateClient, max_concurrency: usize) -> Self {
         Self {
             client,
             samples: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
             baseline: Arc::new(RwLock::new(Vec::new())),
-            throttle_us: Arc::new(AtomicU64::new(0)),
+            concurrency_sem: Arc::new(tokio::sync::Semaphore::new(max_concurrency)),
+            current_concurrency: Arc::new(AtomicU64::new(max_concurrency as u64)),
         }
     }
 
@@ -345,8 +347,11 @@ impl ThreadPoolMonitor {
     ) -> tokio::task::JoinHandle<()> {
         let client = self.client.clone();
         let samples = self.samples.clone();
-        let throttle_us = self.throttle_us.clone();
-        let mut current_throttle: f64 = 0.0;
+        let sem = self.concurrency_sem.clone();
+        let current_concurrency = self.current_concurrency.clone();
+        let max_concurrency = current_concurrency.load(Ordering::Relaxed) as usize;
+        // We hold "stolen" permits here to reduce concurrency
+        let mut stolen_permits: Vec<tokio::sync::OwnedSemaphorePermit> = Vec::new();
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -370,35 +375,57 @@ impl ThreadPoolMonitor {
                                     smap.entry(name).or_default().push(NodeSample { active, queue });
                                 }
                             }
+                            drop(smap); // release write lock before permit operations
 
-                            // Update throttle if enabled
                             if throttle_config.enabled && node_count > 0 {
-                                // Use the average queue across nodes
                                 let avg_queue = total_queue as f64 / node_count as f64;
                                 let queue_pct = avg_queue / throttle_config.capacity as f64;
 
-                                if queue_pct > throttle_config.threshold_pct {
-                                    // Pressure: jump directly to proportional target
-                                    let overshoot = (queue_pct - throttle_config.threshold_pct)
+                                // Desired concurrency: linearly scale down from max when over threshold
+                                let desired = if queue_pct > throttle_config.threshold_pct {
+                                    let pressure = (queue_pct - throttle_config.threshold_pct)
                                         / (1.0 - throttle_config.threshold_pct);
-                                    let target = overshoot * throttle_config.max_throttle_us as f64;
-                                    // Always take the higher of current or target (never reduce under pressure)
-                                    current_throttle = current_throttle.max(target);
+                                    // Scale from max_concurrency down to min_concurrency (25% of max)
+                                    let min_concurrency = (max_concurrency as f64 * 0.25).ceil() as usize;
+                                    let target = max_concurrency as f64 - pressure * (max_concurrency - min_concurrency) as f64;
+                                    (target as usize).max(min_concurrency)
+                                } else if queue_pct < throttle_config.threshold_pct * 0.5 {
+                                    // Well below threshold: restore toward max (release 1 permit per tick)
+                                    let current = max_concurrency - stolen_permits.len();
+                                    (current + 1).min(max_concurrency)
                                 } else {
-                                    // Headroom: slow decay (10% per second)
-                                    current_throttle *= 0.9;
+                                    // Between 50% of threshold and threshold: hold steady
+                                    max_concurrency - stolen_permits.len()
+                                };
+
+                                let current = max_concurrency - stolen_permits.len();
+
+                                if desired < current {
+                                    // Need to reduce: steal permits
+                                    let to_steal = current - desired;
+                                    for _ in 0..to_steal {
+                                        if let Ok(permit) = sem.clone().try_acquire_owned() {
+                                            stolen_permits.push(permit);
+                                        }
+                                    }
+                                } else if desired > current && !stolen_permits.is_empty() {
+                                    // Need to increase: release stolen permits
+                                    let to_release = (desired - current).min(stolen_permits.len());
+                                    stolen_permits.truncate(stolen_permits.len() - to_release);
                                 }
 
-                                // Clamp and store
-                                let clamped = current_throttle
-                                    .max(0.0)
-                                    .min(throttle_config.max_throttle_us as f64) as u64;
-                                throttle_us.store(clamped, Ordering::Relaxed);
+                                current_concurrency.store(
+                                    (max_concurrency - stolen_permits.len()) as u64,
+                                    Ordering::Relaxed,
+                                );
                             }
                         }
                     }
                 }
             }
+
+            // Release all stolen permits on shutdown
+            drop(stolen_permits);
         })
     }
 

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -304,11 +304,22 @@ pub struct ClusterThreadPoolStats {
     pub nodes: Vec<NodeThreadPoolStats>,
 }
 
+/// Configuration for queue-based throttling.
+#[derive(Debug, Clone)]
+pub struct QueueThrottleConfig {
+    pub enabled: bool,
+    pub capacity: u64,
+    pub threshold_pct: f64,
+    pub max_throttle_us: u64,
+}
+
 /// Monitors CrateDB write thread pool by polling sys.nodes during the benchmark.
 pub struct ThreadPoolMonitor {
     client: CrateClient,
     samples: Arc<RwLock<std::collections::BTreeMap<String, Vec<NodeSample>>>>,
     baseline: Arc<RwLock<Vec<NodePoolCounters>>>,
+    /// Current throttle sleep in microseconds, read by workers.
+    pub throttle_us: Arc<AtomicU64>,
 }
 
 impl ThreadPoolMonitor {
@@ -317,6 +328,7 @@ impl ThreadPoolMonitor {
             client,
             samples: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
             baseline: Arc::new(RwLock::new(Vec::new())),
+            throttle_us: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -329,9 +341,12 @@ impl ThreadPoolMonitor {
     pub fn spawn_poller(
         &self,
         mut shutdown_rx: broadcast::Receiver<()>,
+        throttle_config: QueueThrottleConfig,
     ) -> tokio::task::JoinHandle<()> {
         let client = self.client.clone();
         let samples = self.samples.clone();
+        let throttle_us = self.throttle_us.clone();
+        let mut current_throttle: f64 = 0.0;
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -342,14 +357,44 @@ impl ThreadPoolMonitor {
                         if let Ok(rows) = client.execute_query(
                             "SELECT name, thread_pools FROM sys.nodes ORDER BY name"
                         ).await {
+                            let mut total_queue: u64 = 0;
+                            let mut node_count: u64 = 0;
                             let mut smap = samples.write().await;
                             for row in &rows {
                                 let name = row.first().and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
                                 if let Some(pool) = find_write_pool(row.get(1)) {
                                     let active = pool.get("active").and_then(|v| v.as_u64()).unwrap_or(0);
                                     let queue = pool.get("queue").and_then(|v| v.as_u64()).unwrap_or(0);
+                                    total_queue += queue;
+                                    node_count += 1;
                                     smap.entry(name).or_default().push(NodeSample { active, queue });
                                 }
+                            }
+
+                            // Update throttle if enabled
+                            if throttle_config.enabled && node_count > 0 {
+                                // Use the average queue across nodes
+                                let avg_queue = total_queue as f64 / node_count as f64;
+                                let queue_pct = avg_queue / throttle_config.capacity as f64;
+
+                                if queue_pct > throttle_config.threshold_pct {
+                                    // Pressure: ramp up fast
+                                    let overshoot = (queue_pct - throttle_config.threshold_pct)
+                                        / (1.0 - throttle_config.threshold_pct);
+                                    let target = overshoot * throttle_config.max_throttle_us as f64;
+                                    // Fast up: jump to at least 70% old + 30% new, or new if higher
+                                    current_throttle = (0.7 * current_throttle + 0.3 * target)
+                                        .max(current_throttle.min(target));
+                                } else {
+                                    // Headroom: slow decay
+                                    current_throttle *= 0.9;
+                                }
+
+                                // Clamp and store
+                                let clamped = current_throttle
+                                    .max(0.0)
+                                    .min(throttle_config.max_throttle_us as f64) as u64;
+                                throttle_us.store(clamped, Ordering::Relaxed);
                             }
                         }
                     }

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -419,12 +419,20 @@ impl ThreadPoolMonitor {
                                 let current = max_concurrency - extra_stolen;
 
                                 if desired < current {
-                                    // Steal permits by forgetting them
+                                    // Steal permits one at a time — workers hold most permits,
+                                    // so we grab each one as it becomes briefly available.
                                     let to_steal = current - desired;
-                                    // acquire_many will succeed because we have SEM_TOTAL permits total
-                                    if let Ok(permit) = sem.try_acquire_many(to_steal as u32) {
-                                        permit.forget();
-                                        extra_stolen += to_steal;
+                                    for _ in 0..to_steal {
+                                        match tokio::time::timeout(
+                                            std::time::Duration::from_millis(100),
+                                            sem.acquire(),
+                                        ).await {
+                                            Ok(Ok(permit)) => {
+                                                permit.forget();
+                                                extra_stolen += 1;
+                                            }
+                                            _ => break, // timeout or closed, try again next tick
+                                        }
                                     }
                                 } else if desired > current && extra_stolen > 0 {
                                     // Release permits back

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -318,10 +318,16 @@ pub struct ThreadPoolMonitor {
     samples: Arc<RwLock<std::collections::BTreeMap<String, Vec<NodeSample>>>>,
     baseline: Arc<RwLock<Vec<NodePoolCounters>>>,
     /// Semaphore controlling max concurrent in-flight requests.
+    /// Initialized with a large number; the poller holds reserve permits to limit concurrency.
     pub concurrency_sem: Arc<tokio::sync::Semaphore>,
     /// Current target concurrency (for reporting).
     pub current_concurrency: Arc<AtomicU64>,
+    /// Total permits in the semaphore (workers never see more than max_concurrency).
+    total_permits: usize,
 }
+
+// Large enough that we can always steal from the pool without blocking.
+const SEM_TOTAL: usize = 1024;
 
 impl ThreadPoolMonitor {
     pub fn new(client: CrateClient, max_concurrency: usize) -> Self {
@@ -329,8 +335,9 @@ impl ThreadPoolMonitor {
             client,
             samples: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
             baseline: Arc::new(RwLock::new(Vec::new())),
-            concurrency_sem: Arc::new(tokio::sync::Semaphore::new(max_concurrency)),
+            concurrency_sem: Arc::new(tokio::sync::Semaphore::new(SEM_TOTAL)),
             current_concurrency: Arc::new(AtomicU64::new(max_concurrency as u64)),
+            total_permits: SEM_TOTAL,
         }
     }
 
@@ -350,14 +357,28 @@ impl ThreadPoolMonitor {
         let sem = self.concurrency_sem.clone();
         let current_concurrency = self.current_concurrency.clone();
         let max_concurrency = current_concurrency.load(Ordering::Relaxed) as usize;
-        // We hold "stolen" permits here to reduce concurrency
-        let mut stolen_permits: Vec<tokio::sync::OwnedSemaphorePermit> = Vec::new();
+        let total_permits = self.total_permits;
 
         tokio::spawn(async move {
+            // Grab reserve permits: hold (SEM_TOTAL - max_concurrency) so workers
+            // only see max_concurrency available. We use forget() to permanently
+            // remove permits; add_permits() to give them back.
+            let reserve = total_permits - max_concurrency;
+            sem.acquire_many(reserve as u32).await.expect("semaphore closed").forget();
+            // Now sem has exactly max_concurrency permits available.
+            // Track how many we've additionally stolen beyond the initial reserve.
+            let mut extra_stolen: usize = 0;
+
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
             loop {
                 tokio::select! {
-                    _ = shutdown_rx.recv() => break,
+                    _ = shutdown_rx.recv() => {
+                        // Restore all stolen permits on shutdown
+                        if extra_stolen > 0 {
+                            sem.add_permits(extra_stolen);
+                        }
+                        break;
+                    },
                     _ = interval.tick() => {
                         if let Ok(rows) = client.execute_query(
                             "SELECT name, thread_pools FROM sys.nodes ORDER BY name"
@@ -375,47 +396,45 @@ impl ThreadPoolMonitor {
                                     smap.entry(name).or_default().push(NodeSample { active, queue });
                                 }
                             }
-                            drop(smap); // release write lock before permit operations
+                            drop(smap);
 
                             if throttle_config.enabled && node_count > 0 {
                                 let avg_queue = total_queue as f64 / node_count as f64;
                                 let queue_pct = avg_queue / throttle_config.capacity as f64;
 
-                                // Desired concurrency: linearly scale down from max when over threshold
                                 let desired = if queue_pct > throttle_config.threshold_pct {
                                     let pressure = (queue_pct - throttle_config.threshold_pct)
                                         / (1.0 - throttle_config.threshold_pct);
-                                    // Scale from max_concurrency down to min_concurrency (25% of max)
                                     let min_concurrency = (max_concurrency as f64 * 0.25).ceil() as usize;
                                     let target = max_concurrency as f64 - pressure * (max_concurrency - min_concurrency) as f64;
                                     (target as usize).max(min_concurrency)
                                 } else if queue_pct < throttle_config.threshold_pct * 0.5 {
-                                    // Well below threshold: restore toward max (release 1 permit per tick)
-                                    let current = max_concurrency - stolen_permits.len();
+                                    // Well below threshold: restore 1 per tick
+                                    let current = max_concurrency - extra_stolen;
                                     (current + 1).min(max_concurrency)
                                 } else {
-                                    // Between 50% of threshold and threshold: hold steady
-                                    max_concurrency - stolen_permits.len()
+                                    max_concurrency - extra_stolen
                                 };
 
-                                let current = max_concurrency - stolen_permits.len();
+                                let current = max_concurrency - extra_stolen;
 
                                 if desired < current {
-                                    // Need to reduce: steal permits
+                                    // Steal permits by forgetting them
                                     let to_steal = current - desired;
-                                    for _ in 0..to_steal {
-                                        if let Ok(permit) = sem.clone().try_acquire_owned() {
-                                            stolen_permits.push(permit);
-                                        }
+                                    // acquire_many will succeed because we have SEM_TOTAL permits total
+                                    if let Ok(permit) = sem.try_acquire_many(to_steal as u32) {
+                                        permit.forget();
+                                        extra_stolen += to_steal;
                                     }
-                                } else if desired > current && !stolen_permits.is_empty() {
-                                    // Need to increase: release stolen permits
-                                    let to_release = (desired - current).min(stolen_permits.len());
-                                    stolen_permits.truncate(stolen_permits.len() - to_release);
+                                } else if desired > current && extra_stolen > 0 {
+                                    // Release permits back
+                                    let to_release = (desired - current).min(extra_stolen);
+                                    sem.add_permits(to_release);
+                                    extra_stolen -= to_release;
                                 }
 
                                 current_concurrency.store(
-                                    (max_concurrency - stolen_permits.len()) as u64,
+                                    (max_concurrency - extra_stolen) as u64,
                                     Ordering::Relaxed,
                                 );
                             }
@@ -423,9 +442,6 @@ impl ThreadPoolMonitor {
                     }
                 }
             }
-
-            // Release all stolen permits on shutdown
-            drop(stolen_permits);
         })
     }
 


### PR DESCRIPTION
## Concept

CrateDB's write thread pool has a fixed queue (default capacity 200). When the inserter pushes harder than the cluster can digest, the queue fills up and requests get rejected (`EsRejectedExecutionException`). This is wasteful — the client did all the work (generate, serialize, compress, send) only for the server to throw it away.

This PR adds **server-side backpressure** to the HTTP inserter. A background poller reads the write thread pool queue depth from `sys.nodes` every second. When the queue exceeds a configurable threshold (default 50%), a tokio `Semaphore` reduces the number of concurrent in-flight requests — effectively pausing some workers until the server catches up.

### Why a semaphore, not sleep-based throttling?

We tried sleep-based throttling first (adding a delay between batches). It created a **thundering herd** — all 32 workers sleep, then wake and fire simultaneously, producing bursty traffic that actually *increased* server load (from 31 to 39 on 32 cores). The semaphore approach naturally staggers workers: blocked workers resume one-by-one as permits become available, producing smooth, steady pressure.

### How it works

1. The thread pool poller (already existed for monitoring) now also adjusts concurrency
2. A `tokio::Semaphore` starts with `--threads` permits (e.g. 32)
3. Each worker acquires a permit before sending a request, releases it after the response
4. When queue > threshold: the poller **steals permits** (reducing concurrency proportionally, down to 25% of threads)
5. When queue < 50% of threshold: the poller **releases permits** back (1 per second, cautious recovery)
6. New CLI flags: `--queue-throttle` (enable), `--queue-throttle-pct` (threshold, default 50), `--queue-capacity` (default 200)

## Code changes

- **`rust/src/monitor.rs`** — `ThreadPoolMonitor` gains a `Semaphore` and `current_concurrency` atomic. The `spawn_poller()` method now accepts a `QueueThrottleConfig` and adjusts permits each tick based on queue depth. Uses `forget()`/`add_permits()` for reliable permit control.
- **`rust/src/main.rs`** — New CLI args (`--queue-throttle`, `--queue-throttle-pct`, `--queue-capacity`). Workers acquire a semaphore permit before each insert and release it after. JSON output includes `final_concurrency` and throttle config.

## Results (single-node bare-metal CrateDB 6.2.2, 32 CPUs)

9-minute runs, 32 threads, batch size 1000, 32 shards, no compression:

| Metric | No throttle | Semaphore (50% threshold) |
|--------|------------|--------------------------|
| effective rec/cpu/s | 8,985 | 8,999 |
| total records | 155.3M | 155.5M |
| rejected writes | 1,684,833 (1.1%) | 438,126 (0.3%) |
| queue avg | 149.8 / 200 | 87.3 / 200 |
| queue p95 | 200 (wall) | 196 |
| latency avg | 109 ms | 57 ms |
| final concurrency | 32 (no change) | 14 |

**Same throughput, 73% fewer rejections, half the latency.** The semaphore reduced active concurrency from 32 to 14 while maintaining the same total insert rate — the server processes just as fast but with far less queuing pressure.

TLDR; same speed, less load on the server.

Enabled with `--queue-throttle`. Disabled by default — no behavior change without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)