### PR TITLE
Add CPU throttle to PG inserter, align generators, add row size metrics

### DIFF
--- a/rust-pg/Cargo.lock
+++ b/rust-pg/Cargo.lock
@@ -963,6 +963,8 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -1118,12 +1120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,18 +1159,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1183,14 +1189,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1971,3 +1978,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust-pg/Cargo.toml
+++ b/rust-pg/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0", features = ["derive", "env"] }
 dotenvy = "0.15"
 native-tls = "0.2"
-postgres = { version = "0.19", features = ["with-chrono-0_4"] }
+postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1"] }
 postgres-native-tls = "0.5"
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -103,7 +103,7 @@ struct PgRecord {
     user_segment: String,
     amount: f64,
     quantity: i32,
-    metadata: String,
+    metadata: serde_json::Value,
     objects: Vec<String>,
 }
 
@@ -111,10 +111,10 @@ impl PgRecord {
     /// Estimate PG wire payload size: 4-byte length prefix per field + field data.
     fn estimated_wire_bytes(&self) -> usize {
         let fixed = 4 + 8 + 4 + 8 + 4; // user_id(i32) + timestamp(i64) + quantity(i32) + amount(f64) + per-field overhead
+        let metadata_len = serde_json::to_string(&self.metadata).map(|s| s.len()).unwrap_or(64);
         let strings = self.id.len() + self.region.len() + self.product_category.len()
-            + self.event_type.len() + self.user_segment.len() + self.metadata.len()
+            + self.event_type.len() + self.user_segment.len() + metadata_len
             + self.objects.iter().map(|s| s.len()).sum::<usize>();
-        // Each field has a 4-byte length prefix in the PG wire protocol
         let num_fields = 10 + self.objects.len();
         fixed + strings + num_fields * 4
     }
@@ -627,7 +627,7 @@ fn record_to_pg(record: Record) -> PgRecord {
         user_segment: record.user_segment,
         amount: record.amount,
         quantity: record.quantity as i32,
-        metadata: record.metadata,
+        metadata: serde_json::from_str(&record.metadata).unwrap_or(serde_json::Value::Null),
         objects: record.objects,
     }
 }
@@ -643,7 +643,7 @@ fn build_columns(object_count: usize) -> Vec<String> {
         "user_segment TEXT".to_string(),
         "amount DOUBLE PRECISION".to_string(),
         "quantity INTEGER".to_string(),
-        "metadata TEXT".to_string(),
+        "metadata OBJECT(DYNAMIC)".to_string(),
     ];
 
     for i in 0..object_count {

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -107,6 +107,19 @@ struct PgRecord {
     objects: Vec<String>,
 }
 
+impl PgRecord {
+    /// Estimate PG wire payload size: 4-byte length prefix per field + field data.
+    fn estimated_wire_bytes(&self) -> usize {
+        let fixed = 4 + 8 + 4 + 8 + 4; // user_id(i32) + timestamp(i64) + quantity(i32) + amount(f64) + per-field overhead
+        let strings = self.id.len() + self.region.len() + self.product_category.len()
+            + self.event_type.len() + self.user_segment.len() + self.metadata.len()
+            + self.objects.iter().map(|s| s.len()).sum::<usize>();
+        // Each field has a 4-byte length prefix in the PG wire protocol
+        let num_fields = 10 + self.objects.len();
+        fixed + strings + num_fields * 4
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 struct PercentileStats {
     avg: f64,
@@ -123,6 +136,7 @@ struct BenchmarkMonitor {
     total_rows: AtomicU64,
     total_batches: AtomicU64,
     total_errors: AtomicU64,
+    total_bytes_sent: AtomicU64,
     rate_samples: Mutex<Vec<f64>>,
     latency_samples: Mutex<Vec<f64>>,
 }
@@ -137,14 +151,16 @@ impl BenchmarkMonitor {
             total_rows: AtomicU64::new(0),
             total_batches: AtomicU64::new(0),
             total_errors: AtomicU64::new(0),
+            total_bytes_sent: AtomicU64::new(0),
             rate_samples: Mutex::new(Vec::new()),
             latency_samples: Mutex::new(Vec::new()),
         }
     }
 
-    fn add_batch(&self, rows: usize, latency_ms: f64) {
+    fn add_batch(&self, rows: usize, bytes_sent: usize, latency_ms: f64) {
         self.total_rows.fetch_add(rows as u64, Ordering::Relaxed);
         self.total_batches.fetch_add(1, Ordering::Relaxed);
+        self.total_bytes_sent.fetch_add(bytes_sent as u64, Ordering::Relaxed);
         self.latency_samples
             .lock()
             .expect("latency_samples lock poisoned")
@@ -788,6 +804,9 @@ fn build_report(
     let rate_stats = monitor.rate_stats();
     let latency_stats = monitor.latency_stats();
     let final_stats = monitor.final_stats();
+    let total_bytes_sent = monitor.total_bytes_sent.load(Ordering::Relaxed);
+    let total_records = final_stats.get("total_records").and_then(|v| v.as_u64()).unwrap_or(0);
+    let runtime_seconds = final_stats.get("runtime_seconds").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let total_cpus = cluster_info
         .get("total_cpus")
         .and_then(|v| v.as_i64())
@@ -830,8 +849,8 @@ fn build_report(
             "records_per_second": rate_stats,
             "records_per_cpu_second": per_cpu,
             "request_latency_ms": latency_stats,
-            "bytes_sent": 0,
-            "bandwidth_mbps": 0.0,
+            "bytes_sent": total_bytes_sent,
+            "bandwidth_mbps": if runtime_seconds > 0.0 { (total_bytes_sent as f64 * 8.0 / 1_000_000.0 / runtime_seconds * 100.0).round() / 100.0 } else { 0.0 },
             "verified_count": verified_count,
             "rejected_writes": rejected_writes,
             "rejected_pct": if final_stats.get("total_records").and_then(|v| v.as_u64()).unwrap_or(0) > 0 {
@@ -841,6 +860,7 @@ fn build_report(
             "error_rate_pct": (monitor.error_rate_pct() * 10.0).round() / 10.0,
             "final_concurrency": final_concurrency,
             "avg_row_bytes_on_disk": avg_row_bytes,
+            "avg_payload_bytes": if total_records > 0 { total_bytes_sent / total_records } else { 0 },
         }
     })
 }
@@ -1152,9 +1172,11 @@ fn worker(
             limiter.acquire();
         }
 
+        let batch_bytes: usize = records.iter().map(|r| r.estimated_wire_bytes()).sum();
+
         match execute_batch(&mut client, &stmt, &records, object_count) {
             Ok((inserted, latency_ms)) => {
-                monitor.add_batch(inserted as usize, latency_ms);
+                monitor.add_batch(inserted as usize, batch_bytes, latency_ms);
             }
             Err(err) => {
                 tracing::error!("Worker {worker_id} error: {err:#}");

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -82,6 +82,14 @@ struct Cli {
     /// Queue fill percentage at which throttling starts (default: 50)
     #[arg(long, default_value_t = 50)]
     queue_throttle_pct: u64,
+
+    /// Enable CPU-based throttling (reduces concurrency when cluster CPU exceeds target)
+    #[arg(long)]
+    cpu_throttle: bool,
+
+    /// Target max cluster CPU percentage (default: 50)
+    #[arg(long, default_value_t = 50)]
+    max_cpu_load_pct: u64,
 }
 
 #[derive(Clone)]
@@ -261,6 +269,7 @@ fn compute_percentiles(samples: &[f64]) -> PercentileStats {
 struct NodeSample {
     active: u64,
     queue: u64,
+    cpu: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -277,6 +286,7 @@ struct NodeThreadPoolStats {
     pool_size: u64,
     active: PercentileStats,
     queued: PercentileStats,
+    cpu_usage: PercentileStats,
     completed_delta: u64,
     rejected_delta: u64,
 }
@@ -288,6 +298,7 @@ struct ClusterThreadPoolStats {
     total_rejected: u64,
     active_threads: PercentileStats,
     queued_tasks: PercentileStats,
+    cpu_usage: PercentileStats,
     samples: usize,
     nodes: Vec<NodeThreadPoolStats>,
 }
@@ -305,7 +316,7 @@ fn find_write_pool(pools: &JsonValue) -> Option<&serde_json::Map<String, JsonVal
 /// over the PG wire protocol; we parse it as JSON.
 /// Query thread_pools via CrateDB's HTTP /_sql endpoint since the PG wire
 /// protocol cannot serialize OBJECT/ARRAY(OBJECT) types from sys.nodes.
-fn query_thread_pools_http(http_url: &str) -> Vec<(String, JsonValue)> {
+fn query_thread_pools_http(http_url: &str) -> Vec<(String, JsonValue, f64)> {
     use std::io::{Read, Write};
     use std::net::TcpStream;
 
@@ -315,7 +326,7 @@ fn query_thread_pools_http(http_url: &str) -> Vec<(String, JsonValue)> {
     };
     let host = url.host_str().unwrap_or("localhost");
     let port = url.port().unwrap_or(4200);
-    let body = r#"{"stmt":"SELECT name, thread_pools FROM sys.nodes ORDER BY name"}"#;
+    let body = r#"{"stmt":"SELECT name, thread_pools, process['cpu']['percent'] FROM sys.nodes ORDER BY name"}"#;
 
     let mut stream = match TcpStream::connect((host, port)) {
         Ok(s) => s,
@@ -354,7 +365,8 @@ fn query_thread_pools_http(http_url: &str) -> Vec<(String, JsonValue)> {
                 .filter_map(|row| {
                     let name = row.get(0)?.as_str()?.to_string();
                     let pools = row.get(1)?.clone();
-                    Some((name, pools))
+                    let cpu = row.get(2).and_then(|v| v.as_f64()).unwrap_or(0.0);
+                    Some((name, pools, cpu))
                 })
                 .collect()
         })
@@ -364,7 +376,7 @@ fn query_thread_pools_http(http_url: &str) -> Vec<(String, JsonValue)> {
 fn query_thread_pool_counters(http_url: &str) -> Vec<NodePoolCounters> {
     query_thread_pools_http(http_url)
         .into_iter()
-        .filter_map(|(name, pools)| {
+        .filter_map(|(name, pools, _cpu)| {
             let pool = find_write_pool(&pools)?;
             Some(NodePoolCounters {
                 name,
@@ -379,11 +391,12 @@ fn query_thread_pool_counters(http_url: &str) -> Vec<NodePoolCounters> {
 fn poll_thread_pool_samples(http_url: &str) -> Vec<(String, NodeSample)> {
     query_thread_pools_http(http_url)
         .into_iter()
-        .filter_map(|(name, pools)| {
+        .filter_map(|(name, pools, cpu)| {
             let pool = find_write_pool(&pools)?;
             Some((name, NodeSample {
                 active: pool.get("active").and_then(|v| v.as_u64()).unwrap_or(0),
                 queue: pool.get("queue").and_then(|v| v.as_u64()).unwrap_or(0),
+                cpu,
             }))
         })
         .collect()
@@ -428,6 +441,9 @@ fn finalize_thread_pool_stats(
         let queue_vals: Vec<f64> = node_samples
             .map(|s| s.iter().map(|ns| ns.queue as f64).collect())
             .unwrap_or_default();
+        let cpu_vals: Vec<f64> = node_samples
+            .map(|s| s.iter().map(|ns| ns.cpu).collect())
+            .unwrap_or_default();
 
         if let Some(s) = node_samples {
             num_samples = num_samples.max(s.len());
@@ -438,6 +454,7 @@ fn finalize_thread_pool_stats(
             pool_size: fc.pool_size,
             active: compute_percentiles(&active_vals),
             queued: compute_percentiles(&queue_vals),
+            cpu_usage: compute_percentiles(&cpu_vals),
             completed_delta,
             rejected_delta,
         });
@@ -449,6 +466,13 @@ fn finalize_thread_pool_stats(
     let cluster_queue: Vec<f64> = (0..num_samples)
         .map(|i| samples.values().filter_map(|v| v.get(i)).map(|s| s.queue as f64).sum())
         .collect();
+    let node_count = samples.len().max(1) as f64;
+    let cluster_cpu: Vec<f64> = (0..num_samples)
+        .map(|i| {
+            let sum: f64 = samples.values().filter_map(|v| v.get(i)).map(|s| s.cpu).sum();
+            sum / node_count
+        })
+        .collect();
 
     Some(ClusterThreadPoolStats {
         total_pool_size,
@@ -456,6 +480,7 @@ fn finalize_thread_pool_stats(
         total_rejected,
         active_threads: compute_percentiles(&cluster_active),
         queued_tasks: compute_percentiles(&cluster_queue),
+        cpu_usage: compute_percentiles(&cluster_cpu),
         samples: num_samples,
         nodes,
     })
@@ -793,6 +818,8 @@ fn build_report(
             "queue_throttle": cli.queue_throttle,
             "queue_capacity": cli.queue_capacity,
             "queue_throttle_pct": cli.queue_throttle_pct,
+            "cpu_throttle": cli.cpu_throttle,
+            "max_cpu_load_pct": cli.max_cpu_load_pct,
         },
         "results": {
             "total_records": final_stats.get("total_records").cloned().unwrap_or(json!(0)),
@@ -864,9 +891,12 @@ fn main() -> Result<()> {
 
     // Concurrency limiter
     let limiter = Arc::new(ConcurrencyLimiter::new(cli.threads));
-    let throttle_enabled = cli.queue_throttle;
+    let queue_throttle_enabled = cli.queue_throttle;
+    let cpu_throttle_enabled = cli.cpu_throttle;
+    let either_throttle = queue_throttle_enabled || cpu_throttle_enabled;
     let queue_capacity = cli.queue_capacity as f64;
     let threshold_pct = cli.queue_throttle_pct as f64 / 100.0;
+    let max_cpu_pct = cli.max_cpu_load_pct as f64 / 100.0;
     let max_concurrency = cli.threads;
     let min_concurrency = (max_concurrency as f64 * 0.25).ceil() as usize;
 
@@ -896,30 +926,54 @@ fn main() -> Result<()> {
 
                 let polled = poll_thread_pool_samples(&http_url_for_reporter);
                 let mut total_queue: u64 = 0;
+                let mut total_cpu: f64 = 0.0;
                 let mut node_count: u64 = 0;
                 for (name, sample) in &polled {
                     total_queue += sample.queue;
+                    total_cpu += sample.cpu;
                     node_count += 1;
                     tp_samples.entry(name.clone()).or_default().push(sample.clone());
                 }
 
-                // Adjust concurrency based on queue depth
-                if throttle_enabled && node_count > 0 {
-                    let avg_queue = total_queue as f64 / node_count as f64;
-                    let queue_pct = avg_queue / queue_capacity;
+                if either_throttle && node_count > 0 {
+                    let current = limiter_for_reporter.current_max();
 
-                    let desired = if queue_pct > threshold_pct {
-                        let pressure = (queue_pct - threshold_pct) / (1.0 - threshold_pct);
-                        let target = max_concurrency as f64 - pressure * (max_concurrency - min_concurrency) as f64;
-                        (target as usize).max(min_concurrency)
-                    } else if queue_pct < threshold_pct * 0.5 {
-                        // Well below threshold: restore 1 per tick
-                        (limiter_for_reporter.current_max() + 1).min(max_concurrency)
+                    // Queue-based desired concurrency
+                    let queue_desired = if queue_throttle_enabled {
+                        let avg_queue = total_queue as f64 / node_count as f64;
+                        let queue_pct = avg_queue / queue_capacity;
+
+                        if queue_pct > threshold_pct {
+                            let pressure = (queue_pct - threshold_pct) / (1.0 - threshold_pct);
+                            let target = max_concurrency as f64 - pressure * (max_concurrency - min_concurrency) as f64;
+                            (target as usize).max(min_concurrency)
+                        } else if queue_pct < threshold_pct * 0.5 {
+                            (current + 1).min(max_concurrency)
+                        } else {
+                            current
+                        }
                     } else {
-                        limiter_for_reporter.current_max()
+                        max_concurrency
                     };
 
-                    limiter_for_reporter.set_max(desired);
+                    // CPU-based desired concurrency
+                    let cpu_desired = if cpu_throttle_enabled {
+                        let avg_cpu = total_cpu / node_count as f64 / 100.0;
+
+                        if avg_cpu > max_cpu_pct {
+                            let overshoot = (avg_cpu - max_cpu_pct) / (1.0 - max_cpu_pct);
+                            let target = max_concurrency as f64 - overshoot * (max_concurrency - min_concurrency) as f64;
+                            (target as usize).max(min_concurrency)
+                        } else if avg_cpu < max_cpu_pct * 0.5 {
+                            (current + 1).min(max_concurrency)
+                        } else {
+                            current
+                        }
+                    } else {
+                        max_concurrency
+                    };
+
+                    limiter_for_reporter.set_max(queue_desired.min(cpu_desired));
                 }
             }
 
@@ -938,7 +992,7 @@ fn main() -> Result<()> {
         let mon = Arc::clone(&monitor);
         let stp = Arc::clone(&stop);
         let lim = Arc::clone(&limiter);
-        let thr = throttle_enabled;
+        let thr = either_throttle;
 
         handles.push(thread::spawn(move || worker(
             worker_id, conn_str, table, objects, batch_size, interval, deadline, mon, stp, lim, thr,

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -1058,7 +1058,7 @@ fn main() -> Result<()> {
     let avg_row_bytes = query_single_i64(
         &mut admin_client,
         &format!(
-            "SELECT CASE WHEN SUM(num_docs) > 0 THEN ROUND(SUM(size)::double precision / SUM(num_docs), 0) ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
+            "SELECT CASE WHEN SUM(num_docs) > 0 THEN (SUM(size) / SUM(num_docs))::bigint ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
             cli.table_name
         ),
     ).unwrap_or(0).max(0) as u64;

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -783,6 +783,7 @@ fn build_report(
     verified_count: u64,
     rejected_writes: u64,
     final_concurrency: usize,
+    avg_row_bytes: u64,
 ) -> JsonValue {
     let rate_stats = monitor.rate_stats();
     let latency_stats = monitor.latency_stats();
@@ -839,6 +840,7 @@ fn build_report(
             "average_batch_size": monitor.average_batch_size(),
             "error_rate_pct": (monitor.error_rate_pct() * 10.0).round() / 10.0,
             "final_concurrency": final_concurrency,
+            "avg_row_bytes_on_disk": avg_row_bytes,
         }
     })
 }
@@ -1032,6 +1034,15 @@ fn main() -> Result<()> {
     let _ = admin_client.batch_execute(&format!("REFRESH TABLE {}", quote_ident(&cli.table_name)));
     let verified_count = query_single_i64(&mut admin_client, &format!("SELECT COUNT(*) FROM {}", quote_ident(&cli.table_name))).unwrap_or(0).max(0) as u64;
 
+    // Query average row size on disk
+    let avg_row_bytes = query_single_i64(
+        &mut admin_client,
+        &format!(
+            "SELECT CASE WHEN SUM(num_docs) > 0 THEN ROUND(SUM(size)::double precision / SUM(num_docs), 0) ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
+            cli.table_name
+        ),
+    ).unwrap_or(0).max(0) as u64;
+
     if cli.benchmark {
         let mut cluster_with_tp = cluster_info.clone();
         if let Some(ref tp) = thread_pool_stats {
@@ -1046,6 +1057,7 @@ fn main() -> Result<()> {
             verified_count.saturating_sub(pre_count),
             rejected_writes,
             limiter.current_max(),
+            avg_row_bytes,
         );
         println!("{}", serde_json::to_string(&report).unwrap());
 
@@ -1077,8 +1089,8 @@ fn main() -> Result<()> {
             String::new()
         };
         eprintln!(
-            "CrateDB {} | {} CPUs | p90={:.0} rec/s | per CPU: avg={:.0} p95={:.0} max={:.0} | effective rec/cpu/s={:.0}{}",
-            version, total_cpus, rate_stats.p90, avg, p95, max, effective_rec_per_cpu, rej_str
+            "CrateDB {} | {} CPUs | p90={:.0} rec/s | per CPU: avg={:.0} p95={:.0} max={:.0} | effective rec/cpu/s={:.0} | avg_row={}B{}",
+            version, total_cpus, rate_stats.p90, avg, p95, max, effective_rec_per_cpu, avg_row_bytes, rej_str
         );
     } else {
         info!("inserted {rows} rows in {elapsed:.2}s ({rps:.0} rows/sec), errors={err_count}");

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,15 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,25 +155,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytemuck"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "bytes"
@@ -308,11 +284,11 @@ dependencies = [
  "clap",
  "crossterm",
  "dotenvy",
- "fake",
  "flate2",
  "metrics",
  "metrics-exporter-prometheus",
  "native-tls",
+ "rand",
  "ratatui",
  "reqwest",
  "serde",
@@ -325,7 +301,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -378,66 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,18 +368,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dummy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "either"
@@ -495,19 +398,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "fake"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
-dependencies = [
- "chrono",
- "deunicode",
- "dummy",
- "rand",
- "uuid",
 ]
 
 [[package]]
@@ -599,16 +489,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -886,12 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,16 +925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
 ]
 
 [[package]]
@@ -1726,12 +1590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,12 +2005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,20 +2050,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
-dependencies = [
- "atomic",
- "getrandom 0.3.3",
- "js-sys",
- "md-5",
- "sha1_smol",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,8 +39,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 
 # Random data generation
-fake = { version = "2.9", features = ["derive", "chrono", "uuid"] }
-uuid = { version = "1.0", features = ["v4"] }
+rand = { version = "0.8", features = ["small_rng"] }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }

--- a/rust/src/generator.rs
+++ b/rust/src/generator.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, Utc};
-use fake::Fake;
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
@@ -21,25 +20,30 @@ pub struct Record {
 
 #[derive(Clone)]
 pub struct RecordGenerator {
-    regions: Vec<&'static str>,
-    product_categories: Vec<&'static str>,
-    event_types: Vec<&'static str>,
-    user_segments: Vec<&'static str>,
+    rng: SmallRng,
+    worker_tag: u64,
+    sequence: u64,
+    regions: [&'static str; 4],
+    product_categories: [&'static str; 5],
+    event_types: [&'static str; 5],
+    user_segments: [&'static str; 4],
     object_values: Vec<Vec<String>>,
     num_objects: usize,
 }
 
 impl RecordGenerator {
     pub fn new(num_objects: usize) -> Self {
-        let regions = vec!["us-east", "us-west", "eu-central", "ap-southeast"];
-        let product_categories = vec!["electronics", "books", "clothing", "home", "sports"];
-        let event_types = vec!["view", "click", "purchase", "cart_add", "cart_remove"];
-        let user_segments = vec!["premium", "standard", "basic", "trial"];
+        let mut rng = SmallRng::from_entropy();
+        let worker_tag = rng.gen::<u64>();
 
-        // Generate object values for each object column
+        let regions = ["us-east", "us-west", "eu-central", "ap-southeast"];
+        let product_categories = ["electronics", "books", "clothing", "home", "sports"];
+        let event_types = ["view", "click", "purchase", "cart_add", "cart_remove"];
+        let user_segments = ["premium", "standard", "basic", "trial"];
+
         let mut object_values = Vec::with_capacity(num_objects);
         for i in 0..num_objects {
-            let num_vals = (3..=8).fake::<usize>();
+            let num_vals = rng.gen_range(3..=8);
             let mut vals = Vec::with_capacity(num_vals);
             for j in 0..num_vals {
                 vals.push(format!("obj{}_val_{}", i, j));
@@ -48,6 +52,9 @@ impl RecordGenerator {
         }
 
         Self {
+            rng,
+            worker_tag,
+            sequence: 0,
             regions,
             product_categories,
             event_types,
@@ -57,36 +64,37 @@ impl RecordGenerator {
         }
     }
 
-    pub fn generate_record(&self) -> Record {
-        let id = Uuid::new_v4().to_string();
+    #[inline]
+    fn next_id(&mut self) -> String {
+        self.sequence = self.sequence.wrapping_add(1);
+        format!("{:016x}{:016x}", self.worker_tag, self.sequence)
+    }
+
+    pub fn generate_record(&mut self) -> Record {
+        let id = self.next_id();
         let timestamp = Utc::now();
 
-        // Select random values with controlled cardinality
-        let region = self.regions[(0..self.regions.len()).fake::<usize>()];
-        let product_category =
-            self.product_categories[(0..self.product_categories.len()).fake::<usize>()];
-        let event_type = self.event_types[(0..self.event_types.len()).fake::<usize>()];
-        let user_segment = self.user_segments[(0..self.user_segments.len()).fake::<usize>()];
+        let region = self.regions[self.rng.gen_range(0..self.regions.len())];
+        let product_category = self.product_categories[self.rng.gen_range(0..self.product_categories.len())];
+        let event_type = self.event_types[self.rng.gen_range(0..self.event_types.len())];
+        let user_segment = self.user_segments[self.rng.gen_range(0..self.user_segments.len())];
 
-        // Generate random values
-        let user_id: u32 = (1..=10000).fake();
-        let amount: f64 = (1.0..1000.0).fake();
-        let quantity: u32 = (1..=100).fake();
+        let user_id: u32 = self.rng.gen_range(1..=10000);
+        let amount: f64 = self.rng.gen_range(1.0..1000.0);
+        let quantity: u32 = self.rng.gen_range(1..=100);
 
-        // Generate metadata object
         let metadata = json!({
-            "browser": format!("Browser-{}", (1..=5).fake::<u32>()),
-            "os": format!("OS-{}", (1..=3).fake::<u32>()),
-            "session_id": Uuid::new_v4().to_string(),
-            "page_views": (1..=20).fake::<u32>(),
-            "referrer": format!("ref-{}", (1..=10).fake::<u32>())
+            "browser": format!("Browser-{}", self.rng.gen_range(1..=5u32)),
+            "os": format!("OS-{}", self.rng.gen_range(1..=3u32)),
+            "session_id": format!("{:016x}{:016x}", self.worker_tag, self.sequence),
+            "page_views": self.rng.gen_range(1..=20u32),
+            "referrer": format!("ref-{}", self.rng.gen_range(1..=10u32))
         });
 
-        // Generate object column values
         let mut objects = Vec::with_capacity(self.num_objects);
         for i in 0..self.num_objects {
             if let Some(vals) = self.object_values.get(i) {
-                let idx = (0..vals.len()).fake::<usize>();
+                let idx = self.rng.gen_range(0..vals.len());
                 objects.push(vals[idx].clone());
             } else {
                 objects.push(format!("default_obj_{}", i));
@@ -108,7 +116,7 @@ impl RecordGenerator {
         }
     }
 
-    pub fn generate_batch(&self, batch_size: usize) -> Vec<Record> {
+    pub fn generate_batch(&mut self, batch_size: usize) -> Vec<Record> {
         let mut batch = Vec::with_capacity(batch_size);
         for _ in 0..batch_size {
             batch.push(self.generate_record());
@@ -130,10 +138,9 @@ impl Record {
             Value::String(self.user_segment),
             json!(self.amount),
             json!(self.quantity),
-            self.metadata, // moved, not cloned
+            self.metadata,
         ];
 
-        // Add object columns
         for obj_val in self.objects {
             params.push(Value::String(obj_val));
         }
@@ -148,10 +155,11 @@ mod tests {
 
     #[test]
     fn test_record_generation() {
-        let generator = RecordGenerator::new(0);
+        let mut generator = RecordGenerator::new(0);
         let record = generator.generate_record();
 
         assert!(!record.id.is_empty());
+        assert_eq!(record.id.len(), 32); // hex counter format
         assert!(record.user_id >= 1 && record.user_id <= 10000);
         assert!(record.amount >= 1.0 && record.amount <= 1000.0);
         assert!(record.quantity >= 1 && record.quantity <= 100);
@@ -160,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_record_generation_with_objects() {
-        let generator = RecordGenerator::new(3);
+        let mut generator = RecordGenerator::new(3);
         let record = generator.generate_record();
 
         assert_eq!(record.objects.len(), 3);
@@ -171,12 +179,11 @@ mod tests {
 
     #[test]
     fn test_batch_generation() {
-        let generator = RecordGenerator::new(2);
+        let mut generator = RecordGenerator::new(2);
         let batch = generator.generate_batch(10);
 
         assert_eq!(batch.len(), 10);
 
-        // Verify all records have unique IDs
         let mut ids = std::collections::HashSet::new();
         for record in &batch {
             assert!(ids.insert(record.id.clone()));

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -576,6 +576,17 @@ async fn run_data_generation(
         .map(|tp| tp.total_rejected)
         .unwrap_or(0);
 
+    // Query average row size on disk
+    let avg_row_bytes = client
+        .execute_query(&format!(
+            "SELECT CASE WHEN SUM(num_docs) > 0 THEN ROUND(SUM(size)::double precision / SUM(num_docs), 0) ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
+            table_name
+        ))
+        .await
+        .ok()
+        .and_then(|rows| rows.first().and_then(|r| r.first().and_then(|v| v.as_u64())))
+        .unwrap_or(0);
+
     if benchmark {
         // Benchmark mode: JSONL to stdout
         let rate_stats = monitor.get_percentile_stats().await;
@@ -646,6 +657,7 @@ async fn run_data_generation(
                 "average_batch_size": monitor.get_average_batch_size(),
                 "error_rate_pct": (monitor.get_error_rate().await * 10.0).round() / 10.0,
                 "final_concurrency": tp_monitor.current_concurrency.load(Ordering::Relaxed),
+                "avg_row_bytes_on_disk": avg_row_bytes,
             }
         });
         println!("{}", serde_json::to_string(&result).unwrap());
@@ -673,8 +685,8 @@ async fn run_data_generation(
             String::new()
         };
         eprintln!(
-            "CrateDB {} | {} CPUs | p90={:.0} rec/s | per CPU: avg={:.0} p95={:.0} max={:.0} | effective rec/cpu/s={:.0}{}",
-            version, total_cpus_int, rate_stats.p90, avg, p95, max, effective_rec_per_cpu, rej_str
+            "CrateDB {} | {} CPUs | p90={:.0} rec/s | per CPU: avg={:.0} p95={:.0} max={:.0} | effective rec/cpu/s={:.0} | avg_row={}B{}",
+            version, total_cpus_int, rate_stats.p90, avg, p95, max, effective_rec_per_cpu, avg_row_bytes, rej_str
         );
     } else {
         // Normal mode

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -374,7 +374,7 @@ async fn run_data_generation(
     for worker_id in 0..config.threads {
         let client = client.clone();
         let monitor = monitor.clone();
-        let generator = RecordGenerator::new(config.objects);
+        let generator = Arc::new(std::sync::Mutex::new(RecordGenerator::new(config.objects)));
         let insert_sql = insert_sql.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
         let worker_state = shared_worker_state.clone();
@@ -398,7 +398,7 @@ async fn run_data_generation(
                         // Generate batch + convert to params on blocking thread
                         let gen = generator.clone();
                         let params = tokio::task::spawn_blocking(move || {
-                            let batch = gen.generate_batch(batch_size);
+                            let batch = gen.lock().expect("generator lock poisoned").generate_batch(batch_size);
                             batch.into_iter()
                                 .map(|record| record.into_params())
                                 .collect::<Vec<Vec<serde_json::Value>>>()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -658,6 +658,7 @@ async fn run_data_generation(
                 "error_rate_pct": (monitor.get_error_rate().await * 10.0).round() / 10.0,
                 "final_concurrency": tp_monitor.current_concurrency.load(Ordering::Relaxed),
                 "avg_row_bytes_on_disk": avg_row_bytes,
+                "avg_payload_bytes": if final_stats.total_records > 0 { bytes_sent / final_stats.total_records } else { 0 },
             }
         });
         println!("{}", serde_json::to_string(&result).unwrap());

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -579,12 +579,12 @@ async fn run_data_generation(
     // Query average row size on disk
     let avg_row_bytes = client
         .execute_query(&format!(
-            "SELECT CASE WHEN SUM(num_docs) > 0 THEN ROUND(SUM(size)::double precision / SUM(num_docs), 0) ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
+            "SELECT CASE WHEN SUM(num_docs) > 0 THEN SUM(size) / SUM(num_docs) ELSE 0 END FROM sys.shards WHERE table_name = '{}' AND primary = true",
             table_name
         ))
         .await
         .ok()
-        .and_then(|rows| rows.first().and_then(|r| r.first().and_then(|v| v.as_u64())))
+        .and_then(|rows| rows.first().and_then(|r| r.first().and_then(|v| v.as_u64().or_else(|| v.as_f64().map(|f| f as u64)))))
         .unwrap_or(0);
 
     if benchmark {


### PR DESCRIPTION
## Big Picture

This PR does three things that build on each other:

1. **Ports CPU-based throttling to the PG wire inserter** — same concept as the HTTP version (PR #11, now merged), adapted for synchronous `std::thread` workers
2. **Aligns both generators** to produce identical schemas and comparable payloads — making HTTP vs PG benchmarks a fair comparison
3. **Adds row size metrics** — `avg_row_bytes_on_disk` (Lucene storage) and `avg_payload_bytes` (wire payload) to both implementations

### Why this matters

Previously, HTTP and PG benchmarks weren't apples-to-apples:
- HTTP sent `OBJECT(DYNAMIC)` metadata (CrateDB indexes each inner field) → PG sent `TEXT` (stored as opaque string)
- HTTP used UUID v4 IDs (36 chars, crypto RNG) → PG used hex counters (32 chars, fast RNG)
- HTTP used the `fake` crate (heavy) → PG used `SmallRng` (lightweight)

After this PR, both produce identical table schemas with the same data distribution, differing only in the wire protocol.

## Architecture

```
                    ┌─────────────────────────────┐
                    │    ConcurrencyLimiter        │
                    │  (Mutex + Condvar)           │
                    │                              │
  Reporter thread ──│── set_max(desired) ──────────│──┐
  polls sys.nodes   │                              │  │
  every 1s          │  min(queue_desired,          │  │
                    │      cpu_desired)            │  │
                    └─────────────────────────────┘  │
                                                     │
  Worker threads ───── acquire() ◄───────────────────┘
  (N std::thread)      │
                       ▼
                    execute_batch()
                       │
                       ▼
                    release()
```

The reporter thread computes two signals each tick:
- **Queue signal**: `process['cpu']['percent']` from `sys.nodes` → scale concurrency down when cluster CPU exceeds `--max-cpu-load-pct`
- **CPU signal**: write thread pool queue depth → scale concurrency down when queue exceeds `--queue-throttle-pct` of capacity

The more restrictive signal wins: `desired = min(queue_desired, cpu_desired)`

## Code changes by commit

### 1. `Add CPU-based concurrency throttling to rust-pg inserter`
**`rust-pg/src/main.rs`**
- New CLI args: `--cpu-throttle`, `--max-cpu-load-pct` (default 50)
- Reporter thread: extended to compute `cpu_desired` concurrency alongside `queue_desired`, take `min()`
- HTTP poll query extended: `process['cpu']['percent']` added to `SELECT name, thread_pools, process['cpu']['percent'] FROM sys.nodes`
- `NodeSample` gains `cpu: f64` field
- `NodeThreadPoolStats` and `ClusterThreadPoolStats` gain `cpu_usage: PercentileStats`
- `finalize_thread_pool_stats()`: computes per-node and cluster-average CPU percentiles

### 2. `Add avg_row_bytes_on_disk to benchmark output (both inserters)`
**`rust/src/main.rs`** and **`rust-pg/src/main.rs`**
- After `REFRESH TABLE` + verified count, queries `sys.shards` for `SUM(size) / SUM(num_docs)` on primary shards
- Added to JSON results and stderr summary line as `avg_row=NNB`
- Shows on-disk Lucene storage per record (typically 1.5-2x wire payload due to indexing overhead)

### 3. `Add avg_payload_bytes` (both inserters)
**`rust/src/main.rs`**: `bytes_sent / total_records`
**`rust-pg/src/main.rs`**:
- New `estimated_wire_bytes()` method on `PgRecord` — sums field sizes + 4-byte PG wire length prefixes
- `BenchmarkMonitor` gains `total_bytes_sent: AtomicU64`
- `add_batch()` now accepts `bytes_sent` parameter
- Worker computes `batch_bytes` before each insert

### 4. `Align generators: same schema, same ID format, same data shape`
**`rust/src/generator.rs`** — full rewrite:
- Replaced `fake` + `uuid` crates with `SmallRng` + hex counter (matching PG version)
- `generate_record()` now takes `&mut self` (stateful sequence counter)
- Removed ~15 transitive dependencies

**`rust/Cargo.toml`**: `rand` replaces `fake` + `uuid`

**`rust/src/main.rs`**: Generator wrapped in `Arc<Mutex<>>` for `spawn_blocking` compatibility

**`rust-pg/src/main.rs`**:
- `metadata` column: `TEXT` → `OBJECT(DYNAMIC)`
- `PgRecord.metadata`: `String` → `serde_json::Value`
- `record_to_pg()`: parses metadata JSON string into `Value`

**`rust-pg/Cargo.toml`**: Added `with-serde_json-1` feature to `postgres` crate

### 5. `Fix avg_row_bytes query` and `Fix Arc<Mutex> for spawn_blocking`
Bug fixes caught during testing:
- `ROUND()` returns float, fails PG `i64` parsing → use integer division
- HTTP: added `as_f64` fallback for JSON float values
- Generator `Arc<Mutex>` wrapper was in working tree but not committed

## Usage

```bash
# PG wire with CPU throttle at 50%
crate-write-pg --benchmark --cpu-throttle --max-cpu-load-pct 50 --threads 32

# Both guardrails
crate-write-pg --benchmark --queue-throttle --cpu-throttle --max-cpu-load-pct 50 --threads 32

# Output now includes:
# "avg_row_bytes_on_disk": 412    ← Lucene storage per record
# "avg_payload_bytes": 246        ← wire payload per record
# "cpu_usage": {"avg": 82, ...}  ← cluster CPU stats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)