### PR TITLE
Add --table-options for extra CREATE TABLE WITH settings

### DIFF
--- a/README-rust.md
+++ b/README-rust.md
@@ -83,6 +83,9 @@ cargo build --release
 --batch-interval <MS>         Milliseconds between batches (0 = none)
 --threads <COUNT>             Concurrent async worker tasks
 --objects <COUNT>             Extra low-cardinality TEXT columns
+--shards <N>                  Shards for table creation (default: 4)
+--replicas <N>                Replicas for table creation (default: 1)
+--table-options <KEY=VAL,...> Extra WITH options for CREATE TABLE (see below)
 --test-loadbalancer           Run 5-tuple load balancer test and exit
 --benchmark                   Minimal output, JSONL result to stdout
 --log-level <LEVEL>           error, warn, info, debug, trace
@@ -90,6 +93,31 @@ cargo build --release
 ```
 
 Config file values are defaults — CLI args override only when explicitly provided. Connection string comes from `.env` or `--connection-string`.
+
+### `--table-options`
+
+Appends extra parameters to `CREATE TABLE … WITH (…)` as comma-separated `key=value` pairs. Keys with `.` are automatically double-quoted. String values (non-numeric, non-boolean) are automatically wrapped in single quotes — do not add SQL quoting yourself.
+
+```bash
+./target/release/crate-write \
+  --table-name bench \
+  --duration 2 --threads 32 --batch-size 1000 \
+  --table-options "translog.durability=ASYNC,translog.sync_interval=10s,translog.flush_threshold_size=512mb"
+```
+
+Generated SQL:
+```sql
+WITH (number_of_replicas = 0, "translog.durability" = 'ASYNC', "translog.sync_interval" = '10s', "translog.flush_threshold_size" = '512mb')
+```
+
+With `--benchmark`, the active options appear in the JSON output under `config.table_options`:
+```json
+"table_options": {
+  "translog.durability": "ASYNC",
+  "translog.sync_interval": "10s",
+  "translog.flush_threshold_size": "512mb"
+}
+```
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,28 @@ Both implementations accept the same flags:
 --batch-interval        Delay between batches: seconds (Python) / ms (Rust)
 --threads               Concurrent async tasks (default: 1)
 --objects               Extra low-cardinality TEXT columns (default: 0)
+--shards                Number of shards for table creation (default: 4)
+--replicas              Number of replicas for table creation (default: 1)
+--table-options         Extra WITH options for CREATE TABLE (Rust only, see below)
 --test-loadbalancer     Run 5-tuple load balancer test and exit
 --benchmark             Minimal output, JSONL result to stdout
 ```
+
+### `--table-options` (Rust only)
+
+Appends extra parameters to the `CREATE TABLE … WITH (…)` clause as comma-separated `key=value` pairs. Keys containing `.` are automatically double-quoted. String values are automatically single-quoted — do not add SQL quotes yourself.
+
+```bash
+--table-options "translog.durability=ASYNC,translog.sync_interval=10s,translog.flush_threshold_size=512mb"
+```
+
+Generates:
+
+```sql
+WITH (number_of_replicas = 0, "translog.durability" = 'ASYNC', "translog.sync_interval" = '10s', "translog.flush_threshold_size" = '512mb')
+```
+
+When `--benchmark` is set, the active options appear in the JSON output under `config.table_options`.
 
 ## Benchmark Mode
 
@@ -132,7 +151,10 @@ CREATE TABLE IF NOT EXISTS your_table (
     quantity INTEGER,
     metadata OBJECT(DYNAMIC)
     -- obj_0 TEXT, obj_1 TEXT, ... when using --objects
-) WITH (number_of_replicas = 1)
+) WITH (
+    number_of_replicas = 1
+    -- extra WITH options injected via --table-options (Rust)
+)
 ```
 
 ## Performance Tuning

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -92,8 +92,9 @@ struct Cli {
     max_cpu_load_pct: u64,
 
     /// Extra WITH options appended to CREATE TABLE, as comma-separated key=value pairs.
-    /// Keys containing '.' are automatically double-quoted.
-    /// Example: "translog.durability='ASYNC',translog.flush_threshold_size='512mb'"
+    /// Keys containing '.' are automatically double-quoted. String values are
+    /// automatically single-quoted — do NOT add SQL quotes yourself.
+    /// Example: "translog.durability=ASYNC,translog.flush_threshold_size=512mb"
     #[arg(long)]
     table_options: Option<String>,
 }
@@ -705,6 +706,24 @@ fn parse_table_options(s: &str) -> anyhow::Result<Vec<(String, String)>> {
     Ok(result)
 }
 
+/// Wrap a bare value in single quotes for SQL unless it is already quoted,
+/// a plain integer/float, or a boolean.  This lets callers pass raw values
+/// (e.g. `10s`, `ASYNC`) without worrying about SQL string literals, which
+/// is important because shell quoting inside `bash -c "..."` strips single
+/// quotes before the binary ever sees them.
+fn to_sql_value(v: &str) -> String {
+    if (v.starts_with('\'') && v.ends_with('\'') && v.len() >= 2)
+        || v.parse::<i64>().is_ok()
+        || v.parse::<f64>().is_ok()
+        || v.eq_ignore_ascii_case("true")
+        || v.eq_ignore_ascii_case("false")
+    {
+        v.to_string()
+    } else {
+        format!("'{}'", v)
+    }
+}
+
 fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> String {
     let mut parts = vec![format!("number_of_replicas = {}", replicas)];
     for (key, value) in table_options {
@@ -713,7 +732,7 @@ fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> Str
         } else {
             key.clone()
         };
-        parts.push(format!("{} = {}", quoted_key, value));
+        parts.push(format!("{} = {}", quoted_key, to_sql_value(value)));
     }
     parts.join(", ")
 }

--- a/rust-pg/src/main.rs
+++ b/rust-pg/src/main.rs
@@ -90,6 +90,12 @@ struct Cli {
     /// Target max cluster CPU percentage (default: 50)
     #[arg(long, default_value_t = 50)]
     max_cpu_load_pct: u64,
+
+    /// Extra WITH options appended to CREATE TABLE, as comma-separated key=value pairs.
+    /// Keys containing '.' are automatically double-quoted.
+    /// Example: "translog.durability='ASYNC',translog.flush_threshold_size='512mb'"
+    #[arg(long)]
+    table_options: Option<String>,
 }
 
 #[derive(Clone)]
@@ -653,14 +659,88 @@ fn build_columns(object_count: usize) -> Vec<String> {
     cols
 }
 
-fn create_table_sql(table_name: &str, shards: usize, replicas: usize, object_count: usize) -> String {
+fn parse_kv_pair(s: &str) -> anyhow::Result<(String, String)> {
+    let eq = s.find('=').ok_or_else(|| anyhow::anyhow!(
+        "invalid table option {:?}: expected key=value", s
+    ))?;
+    let key = s[..eq].trim().to_string();
+    let value = s[eq + 1..].trim().to_string();
+    if key.is_empty() {
+        anyhow::bail!("empty key in table option {:?}", s);
+    }
+    if value.is_empty() {
+        anyhow::bail!("empty value in table option {:?}", s);
+    }
+    Ok((key, value))
+}
+
+fn parse_table_options(s: &str) -> anyhow::Result<Vec<(String, String)>> {
+    let mut result = Vec::new();
+    let mut token = String::new();
+    let mut in_quotes = false;
+
+    for ch in s.chars() {
+        match ch {
+            '\'' => {
+                in_quotes = !in_quotes;
+                token.push(ch);
+            }
+            ',' if !in_quotes => {
+                let pair = token.trim().to_string();
+                if !pair.is_empty() {
+                    result.push(parse_kv_pair(&pair)?);
+                }
+                token.clear();
+            }
+            _ => token.push(ch),
+        }
+    }
+    if in_quotes {
+        anyhow::bail!("unterminated single quote in --table-options");
+    }
+    let pair = token.trim().to_string();
+    if !pair.is_empty() {
+        result.push(parse_kv_pair(&pair)?);
+    }
+    Ok(result)
+}
+
+fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> String {
+    let mut parts = vec![format!("number_of_replicas = {}", replicas)];
+    for (key, value) in table_options {
+        let quoted_key = if key.contains('.') {
+            format!("\"{}\"", key)
+        } else {
+            key.clone()
+        };
+        parts.push(format!("{} = {}", quoted_key, value));
+    }
+    parts.join(", ")
+}
+
+fn table_options_to_json(opts: &[(String, String)]) -> serde_json::Value {
+    let map: serde_json::Map<String, serde_json::Value> = opts
+        .iter()
+        .map(|(k, v)| {
+            let val = if v.starts_with('\'') && v.ends_with('\'') && v.len() >= 2 {
+                serde_json::Value::String(v[1..v.len() - 1].to_string())
+            } else {
+                serde_json::Value::String(v.clone())
+            };
+            (k.clone(), val)
+        })
+        .collect();
+    serde_json::Value::Object(map)
+}
+
+fn create_table_sql(table_name: &str, shards: usize, replicas: usize, object_count: usize, table_options: &[(String, String)]) -> String {
     let columns = build_columns(object_count).join(", ");
     format!(
-        "CREATE TABLE IF NOT EXISTS {} ({}) CLUSTERED INTO {} SHARDS WITH (number_of_replicas = {})",
+        "CREATE TABLE IF NOT EXISTS {} ({}) CLUSTERED INTO {} SHARDS WITH ({})",
         quote_ident(table_name),
         columns,
         shards,
-        replicas
+        build_with_clause(replicas, table_options)
     )
 }
 
@@ -795,6 +875,7 @@ fn build_report(
     cluster_info: JsonValue,
     table_name: &str,
     cli: &Cli,
+    table_options: &[(String, String)],
     monitor: &BenchmarkMonitor,
     verified_count: u64,
     rejected_writes: u64,
@@ -820,7 +901,7 @@ fn build_report(
         p95: (rate_stats.p95 / total_cpus * 10.0).round() / 10.0,
     };
 
-    json!({
+    let mut report = json!({
         "timestamp": Utc::now().to_rfc3339(),
         "client": "rust-pg",
         "cluster": cluster_info,
@@ -862,7 +943,11 @@ fn build_report(
             "avg_row_bytes_on_disk": avg_row_bytes,
             "avg_payload_bytes": if total_records > 0 { total_bytes_sent / total_records } else { 0 },
         }
-    })
+    });
+    if !table_options.is_empty() {
+        report["config"]["table_options"] = table_options_to_json(table_options);
+    }
+    report
 }
 
 fn init_tracing(level: &str) {
@@ -896,10 +981,15 @@ fn main() -> Result<()> {
         "starting CrateDB PostgreSQL inserter"
     );
 
+    let table_options: Vec<(String, String)> = match cli.table_options.as_deref() {
+        Some(raw) => parse_table_options(raw).context("invalid --table-options")?,
+        None => Vec::new(),
+    };
+
     let mut admin_client = connect(&cli.connection_string)?;
 
     if !cli.no_create_table {
-        let sql = create_table_sql(&cli.table_name, cli.shards, cli.replicas, cli.objects);
+        let sql = create_table_sql(&cli.table_name, cli.shards, cli.replicas, cli.objects, &table_options);
         admin_client
             .batch_execute(&sql)
             .with_context(|| format!("failed to create table {}", cli.table_name))?;
@@ -1073,6 +1163,7 @@ fn main() -> Result<()> {
             cluster_with_tp,
             &cli.table_name,
             &cli,
+            &table_options,
             &monitor,
             verified_count.saturating_sub(pre_count),
             rejected_writes,

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -36,6 +36,10 @@ pub struct Config {
     pub shards: usize,
     #[serde(default = "default_replicas")]
     pub replicas: usize,
+    /// Extra WITH options injected into CREATE TABLE, parsed from --table-options.
+    /// Skipped in config files; populated from CLI only.
+    #[serde(skip)]
+    pub table_options: Vec<(String, String)>,
     #[cfg(feature = "dashboard")]
     pub dashboard: bool,
     pub log_level: String,
@@ -87,6 +91,7 @@ impl Default for Config {
             objects: 0,
             shards: 4,
             replicas: 1,
+            table_options: Vec::new(),
             adaptive_batching: default_adaptive_batching(),
             min_batch_size: default_min_batch_size(),
             max_batch_size: default_max_batch_size(),

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -146,8 +146,9 @@ struct Cli {
     max_cpu_load_pct: u64,
 
     /// Extra WITH options appended to CREATE TABLE, as comma-separated key=value pairs.
-    /// Keys containing '.' are automatically double-quoted.
-    /// Example: "translog.durability='ASYNC',translog.flush_threshold_size='512mb'"
+    /// Keys containing '.' are automatically double-quoted. String values are
+    /// automatically single-quoted — do NOT add SQL quotes yourself.
+    /// Example: "translog.durability=ASYNC,translog.flush_threshold_size=512mb"
     #[arg(long)]
     table_options: Option<String>,
 }
@@ -212,6 +213,24 @@ fn parse_table_options(s: &str) -> Result<Vec<(String, String)>> {
     Ok(result)
 }
 
+/// Wrap a bare value in single quotes for SQL unless it is already quoted,
+/// a plain integer/float, or a boolean.  This lets callers pass raw values
+/// (e.g. `10s`, `ASYNC`) without worrying about SQL string literals, which
+/// is important because shell quoting inside `bash -c "..."` strips single
+/// quotes before the binary ever sees them.
+fn to_sql_value(v: &str) -> String {
+    if (v.starts_with('\'') && v.ends_with('\'') && v.len() >= 2)
+        || v.parse::<i64>().is_ok()
+        || v.parse::<f64>().is_ok()
+        || v.eq_ignore_ascii_case("true")
+        || v.eq_ignore_ascii_case("false")
+    {
+        v.to_string()
+    } else {
+        format!("'{}'", v)
+    }
+}
+
 fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> String {
     let mut parts = vec![format!("number_of_replicas = {}", replicas)];
     for (key, value) in table_options {
@@ -220,7 +239,7 @@ fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> Str
         } else {
             key.clone()
         };
-        parts.push(format!("{} = {}", quoted_key, value));
+        parts.push(format!("{} = {}", quoted_key, to_sql_value(value)));
     }
     parts.join(", ")
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -144,6 +144,12 @@ struct Cli {
     /// Target max cluster CPU percentage (default: 50)
     #[arg(long, default_value_t = 50)]
     max_cpu_load_pct: u64,
+
+    /// Extra WITH options appended to CREATE TABLE, as comma-separated key=value pairs.
+    /// Keys containing '.' are automatically double-quoted.
+    /// Example: "translog.durability='ASYNC',translog.flush_threshold_size='512mb'"
+    #[arg(long)]
+    table_options: Option<String>,
 }
 
 fn sanitize_connection_string(connection_string: &str) -> String {
@@ -160,12 +166,87 @@ fn sanitize_connection_string(connection_string: &str) -> String {
     }
 }
 
+fn parse_kv_pair(s: &str) -> Result<(String, String)> {
+    let eq = s.find('=').ok_or_else(|| anyhow::anyhow!(
+        "invalid table option {:?}: expected key=value", s
+    ))?;
+    let key = s[..eq].trim().to_string();
+    let value = s[eq + 1..].trim().to_string();
+    if key.is_empty() {
+        anyhow::bail!("empty key in table option {:?}", s);
+    }
+    if value.is_empty() {
+        anyhow::bail!("empty value in table option {:?}", s);
+    }
+    Ok((key, value))
+}
+
+fn parse_table_options(s: &str) -> Result<Vec<(String, String)>> {
+    let mut result = Vec::new();
+    let mut token = String::new();
+    let mut in_quotes = false;
+
+    for ch in s.chars() {
+        match ch {
+            '\'' => {
+                in_quotes = !in_quotes;
+                token.push(ch);
+            }
+            ',' if !in_quotes => {
+                let pair = token.trim().to_string();
+                if !pair.is_empty() {
+                    result.push(parse_kv_pair(&pair)?);
+                }
+                token.clear();
+            }
+            _ => token.push(ch),
+        }
+    }
+    if in_quotes {
+        anyhow::bail!("unterminated single quote in --table-options");
+    }
+    let pair = token.trim().to_string();
+    if !pair.is_empty() {
+        result.push(parse_kv_pair(&pair)?);
+    }
+    Ok(result)
+}
+
+fn build_with_clause(replicas: usize, table_options: &[(String, String)]) -> String {
+    let mut parts = vec![format!("number_of_replicas = {}", replicas)];
+    for (key, value) in table_options {
+        let quoted_key = if key.contains('.') {
+            format!("\"{}\"", key)
+        } else {
+            key.clone()
+        };
+        parts.push(format!("{} = {}", quoted_key, value));
+    }
+    parts.join(", ")
+}
+
+fn table_options_to_json(opts: &[(String, String)]) -> serde_json::Value {
+    let map: serde_json::Map<String, serde_json::Value> = opts
+        .iter()
+        .map(|(k, v)| {
+            let val = if v.starts_with('\'') && v.ends_with('\'') && v.len() >= 2 {
+                serde_json::Value::String(v[1..v.len() - 1].to_string())
+            } else {
+                serde_json::Value::String(v.clone())
+            };
+            (k.clone(), val)
+        })
+        .collect();
+    serde_json::Value::Object(map)
+}
+
 async fn create_table(
     client: &CrateClient,
     table_name: &str,
     objects: usize,
     shards: usize,
     replicas: usize,
+    table_options: &[(String, String)],
 ) -> Result<()> {
     let mut columns = vec![
         "id TEXT PRIMARY KEY".to_string(),
@@ -186,11 +267,11 @@ async fn create_table(
     }
 
     let sql = format!(
-        "CREATE TABLE IF NOT EXISTS {} ({}) CLUSTERED INTO {} SHARDS WITH (number_of_replicas = {})",
+        "CREATE TABLE IF NOT EXISTS {} ({}) CLUSTERED INTO {} SHARDS WITH ({})",
         table_name,
         columns.join(", "),
         shards,
-        replicas
+        build_with_clause(replicas, table_options)
     );
 
     info!("Creating table: {}", table_name);
@@ -308,6 +389,7 @@ async fn run_data_generation(
         config.objects,
         config.shards,
         config.replicas,
+        &config.table_options,
     )
     .await?;
 
@@ -611,7 +693,7 @@ async fn run_data_generation(
             cluster_with_tp["write_thread_pool"] = serde_json::json!(tp);
         }
 
-        let result = serde_json::json!({
+        let mut result = serde_json::json!({
             "timestamp": chrono::Utc::now().to_rfc3339(),
             "client": "rust-http",
             "cluster": cluster_with_tp,
@@ -661,6 +743,9 @@ async fn run_data_generation(
                 "avg_payload_bytes": if final_stats.total_records > 0 { bytes_sent / final_stats.total_records } else { 0 },
             }
         });
+        if !config.table_options.is_empty() {
+            result["config"]["table_options"] = table_options_to_json(&config.table_options);
+        }
         println!("{}", serde_json::to_string(&result).unwrap());
         // Summary to stderr for quick reading
         let version = cluster_info
@@ -1198,6 +1283,10 @@ async fn main() -> Result<()> {
     }
     if let Some(replicas) = cli.replicas {
         config.replicas = replicas;
+    }
+    if let Some(ref raw) = cli.table_options {
+        config.table_options = parse_table_options(raw)
+            .context("invalid --table-options")?;
     }
 
     // Adaptive batching CLI overrides

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -275,6 +275,7 @@ async fn create_table(
     );
 
     info!("Creating table: {}", table_name);
+    debug!("CREATE TABLE SQL: {}", sql);
     client
         .execute(&sql, &[])
         .await


### PR DESCRIPTION
## Summary

- **`--table-options key=val,...`** — new CLI arg on both `rust-http` and `rust-pg` inserters that appends extra `WITH (...)` parameters to `CREATE TABLE`; keys with `.` are auto double-quoted, string values are auto single-quoted (no SQL quoting needed from the caller)
- **Shell-quoting fix** — auto-quote non-numeric/non-boolean values in `build_with_clause` so bare values like `ASYNC` or `10s` work correctly inside `bash -c "..."` without inner quotes stripping them
- **JSON output** — active options appear under `config.table_options` in benchmark output when the flag is used
- **Docs** — `README.md` and `README-rust.md` updated with usage, generated SQL example, and JSON output shape

## Test plan

- [ ] `--table-options "translog.durability=ASYNC,translog.sync_interval=5s,refresh_interval=10000"` produces correct WITH clause in `SHOW CREATE TABLE`
- [ ] Benchmark JSON contains `config.table_options` when flag is set, absent when not
- [ ] Integer values (`10000`) pass through unquoted; string values (`ASYNC`, `5s`) get single-quoted automatically
- [ ] Malformed input (missing `=`, empty key/value) exits with a clear error before any DB connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)